### PR TITLE
Handle unicode characters in job/nodes parameters

### DIFF
--- a/pyslurm/slurm.pxd
+++ b/pyslurm/slurm.pxd
@@ -55,7 +55,7 @@ cdef inline stringOrNone(char* value, value2):
 		if value2 is '':
 			return None
 		return u"%s" % value2
-	return u"%s" % value
+	return u"%s" % value.decode('utf-8')
 
 cdef inline boolToString(int value):
 	if value == 0:


### PR DESCRIPTION
PySLURM crashes when there is non-ascii character in job/nodes parameters. This commit ensures the data from slurm is decoded from utf-8 to python unicode.