### PR TITLE
Fix badly formatted topology hostlists

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -4045,13 +4045,13 @@ cdef class topology:
 
                 name = u"%s" % self._topo_info_ptr.topo_array[i].name
                 Topo_dict[u'name'] = name
-                Topo_dict[u'nodes'] = slurm.listOrNone(
-                    self._topo_info_ptr.topo_array[i].nodes, ',')
+                Topo_dict[u'nodes'] = slurm.stringOrNone(
+                    self._topo_info_ptr.topo_array[i].nodes, '')
 
                 Topo_dict[u'level'] = self._topo_info_ptr.topo_array[i].level
                 Topo_dict[u'link_speed'] = self._topo_info_ptr.topo_array[i].link_speed
-                Topo_dict[u'switches'] = slurm.listOrNone(
-                    self._topo_info_ptr.topo_array[i].switches, ',')
+                Topo_dict[u'switches'] = slurm.stringOrNone(
+                    self._topo_info_ptr.topo_array[i].switches, '')
 
                 Topo[name] = Topo_dict
 


### PR DESCRIPTION
The switches and nodes linked to a switch are now given as a string
hostlist (or None) instead of a list splitted by commas that could
cause badly formatted hostlists.

Before:

```
>>> import pyslurm
>>> pyslurm.topology().get()
{
 u'swibfstl2': {
  u'link_speed': 1,
  u'switches': [],
  u'nodes': ['cn2'],
  u'name': u'swibfstl2',
  u'level': 0},
 u'swibfstl1': {
  u'link_speed': 1,
  u'switches': [],
  u'nodes': ['cn[1', '3]'],
  u'name': u'swibfstl1',
  u'level': 0},
 u'swibfstl5': {
  u'link_speed': 1,
  u'switches': [],
  u'nodes': ['cn3'],
  u'name': u'swibfstl5',
  u'level': 0},
 u'swibcore01': {
  u'link_speed': 1,
  u'switches': ['swibfstl[1-2', '5]'],
  u'nodes': ['cn[1-3]'],
  u'name': u'swibcore01',
  u'level': 1},
 u'swibcore02': {
  u'link_speed': 1,
  u'switches': ['swibfstl[1-2', '5]'],
  u'nodes': ['cn[1-3]'],
  u'name': u'swibcore02',
  u'level': 1}}
```

(Note the lists `['cn[1', '3]']` and `['swibfstl[1-2', '5]']`)

After:

```
>>> import pyslurm
>>> pyslurm.topology().get()
{
 u'swibfstl2': {
  u'link_speed': 1,
  u'switches': None,
  u'nodes': u'cn2',
  u'name': u'swibfstl2',
  u'level': 0},
 u'swibfstl1': {
  u'link_speed': 1,
  u'switches': None,
  u'nodes': u'cn[1,3]',
  u'name': u'swibfstl1',
  u'level': 0},
 u'swibfstl5': {
  u'link_speed': 1,
  u'switches': None,
  u'nodes': u'cn3',
  u'name': u'swibfstl5',
  u'level': 0},
 u'swibcore01': {
  u'link_speed': 1,
  u'switches': u'swibfstl[1-2,5]',
  u'nodes': u'cn[1-3]',
  u'name': u'swibcore01',
  u'level': 1},
 u'swibcore02': {
  u'link_speed': 1,
  u'switches': u'swibfstl[1-2,5]',
  u'nodes': u'cn[1-3]',
  u'name': u'swibcore02',
  u'level': 1}}
```

Then those strings hostlists could eventually be given to any python
hostlist library (such as clustershell nodeset) to expand them and get
the correct list.