### PR TITLE
Add slurmdb API support

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -73,6 +73,30 @@ Reservation Class
 .. autoclass:: pyslurm.reservation
    :members:
 
+Slurmdb Events Class
+********************
+
+.. autoclass:: pyslurm.slurmdb_events
+   :members:
+
+Slurmdb Reservations Class
+**************************
+
+.. autoclass:: pyslurm.slurmdb_reservations
+   :members:
+
+Slurmdb Clusters Class
+**********************
+
+.. autoclass:: pyslurm.slurmdb_clusters
+   :members:
+
+Slurmdb Jobs Class
+******************
+
+.. autoclass:: pyslurm.slurmdb_jobs
+   :members:
+
 Statistics Class
 ****************
 

--- a/examples/listdb_cluster.py
+++ b/examples/listdb_cluster.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import time as tm
+from datetime import datetime
+import pyslurm
+
+def cluster_display( cluster ):
+    for key,value in cluster.items():
+        if key == 'accounting':
+            print("\t accounting {")
+            for acct_key, acct_value in value.items():
+                print("\t\t{}={}".format(acct_key, acct_value))
+            print("\t }")
+        else:
+            print("\t{}={}".format(key, value))
+
+if __name__ == "__main__":
+    try:
+        start = (datetime(2016,12,1) - datetime(1970,1,1)).total_seconds()
+        end = (datetime(2016,12,2) - datetime(1970,1,1)).total_seconds() - 1
+        print("start={}, end={}".format(start,end))
+        clusters = pyslurm.slurmdb_clusters()
+        print(clusters.set_cluster_condition(start,end))
+        clusters_dict = clusters.get()
+        if len(clusters_dict):
+            for key, value in clusters_dict.items():
+                print("{} Clusters: {}".format('{',key))
+                cluster_display( value)
+                print("}")
+        else:
+            print("No cluster found --")
+    except ValueError as e:
+        print("Error:{}".format(e.args[0]))
+

--- a/examples/listdb_events.py
+++ b/examples/listdb_events.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import time
+from datetime import datetime
+import sys
+import pyslurm
+
+def event_display(event):
+    for key,value in event.items():
+        if (key == "time_start") or (key == "time_end") :
+            print ("\t{}={}  <->  {}".format(key, value, datetime.fromtimestamp(value)))
+        else :
+            print ("\t{}={}".format(key, value))
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) != 3 :
+            print("usage: python listdb_events.py start-tme end-time")
+            print("(format: yyyy-mm-dd)")
+            exit(1)
+
+        start = time.mktime(time.strptime(sys.argv[1], '%Y-%m-%d'))
+        end = time.mktime(time.strptime(sys.argv[2], '%Y-%m-%d'))
+        print("start={}, end={}".format(start, end))
+
+        events = pyslurm.slurmdb_events()
+        events.set_event_condition(start, end)
+        events_dict = events.get()
+        ii = 0
+        if len(events_dict):
+            for key, value in events_dict.items():
+                d = int(value['time_end']) - int(value['time_start'])
+                ii +=1
+                print("{")
+                event_display(value)
+                print("}")
+        else:
+            print("No event found")
+    except ValueError as e:
+        print("Error:{}".format(e.args[0]))
+

--- a/examples/listdb_jobs.py
+++ b/examples/listdb_jobs.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import time
+import pyslurm
+
+def job_display( job ):
+    for key,value in job.items():
+        print("\t{}={}".format(key, value))
+
+if __name__ == "__main__":
+    try:
+        end = time.time()
+        start = end - (30*24*60*60)
+        print("start={}, end={}".format(start,end))
+        jobs = pyslurm.slurmdb_jobs()
+        jobs_dict = jobs.get(starttime=start, endtime=end)
+        if len(jobs_dict):
+            for key, value in jobs_dict.items():
+                print("{} Job: {}".format('{',key))
+                job_display(value)
+                print("}")
+        else:
+            print("No job found")
+    except ValueError as e:
+        print("Error:{}".format(e.args[0]))
+

--- a/examples/listdb_qos.py
+++ b/examples/listdb_qos.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import pyslurm
+
+if __name__ == "__main__":
+    try:
+        qos_dict = pyslurm.qos().get()
+        if len(qos_dict):
+            for key, value in qos_dict.items():
+                print("{")
+                if type(value) is dict:
+                    print("\t{}=".format(key))
+                    for k, v in value.items():
+                        print("\t\t{}={}".format(k, v))
+                else:
+                    print("\t{}={}".format(key, value))
+                print("}")
+        else:
+            print("No QOS found")
+    except ValueError as e:
+        print("Error:{}".format(e.args[0]))
+

--- a/examples/listdb_reservations.py
+++ b/examples/listdb_reservations.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import time
+import pyslurm
+
+def reservation_display(reservation):
+    if reservation:
+        for key,value in reservation.items():
+           print("\t{}={}".format(key, value))
+
+if __name__ == "__main__":
+    try:
+        end = time.time()
+        start = end - (30*24*60*60)
+        print("start={}, end={}".format(start, end))
+        reservations = pyslurm.slurmdb_reservations()
+        reservations.set_reservation_condition(start, end)
+        reservations_dict = reservations.get()
+        if len(reservations_dict):
+            for key, value in reservations_dict.items():
+                print("{} Reservation: {}".format('{', key))
+                reservation_display(value)
+                print("}")
+        else:
+            print("No reservation found")
+    except ValueError as e:
+        print("Error:{}".format(e.args[0]))
+

--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -4765,6 +4765,545 @@ cdef class qos:
 
         self._QOSDict = Q_dict
 
+#
+# slurmdbd jobs Class
+#
+cdef class slurmdb_jobs:
+    u"""Class to access Slurmdbd Jobs information."""
+
+    cdef:
+        pass
+
+    def __cinit__(self):
+        pass
+
+    def __dealloc__(self):
+        self.__destroy()
+
+    cpdef __destroy(self):
+        u"""Destructor method."""
+        pass
+
+    def get(self, jobids=[], starttime=0, endtime=0):
+        u"""Get Slurmdb information about some jobs.
+
+        :param jobids: Ids of the jobs to search. [] for any id
+        :param starttime: Select jobs eligible after this timestamp
+        :param endtime: Select jobs eligible before this timestamp
+        :returns: Dictionary whose key is the JOBS ID
+        :rtype: `dict`
+        """
+        return self.__get(jobids, starttime, endtime)
+
+    cpdef __get(self, list jobids, time_t starttime, time_t endtime):
+        cdef:
+            slurm.ListIterator iters = NULL
+            int i = 0
+            int listNum = 0
+            dict J_dict = {}
+            int apiError = 0
+            slurm.List JOBSList
+            void* dbconn
+            slurm.slurmdb_job_cond_t query
+            slurm.List query_step_list = slurm.slurm_list_create(slurm.slurmdb_destroy_selected_step)
+            slurm.slurmdb_selected_step_t* selstep
+        for j in jobids:
+            selstep = <slurm.slurmdb_selected_step_t*> slurm.xmalloc(sizeof(slurm.slurmdb_selected_step_t))
+            selstep.array_task_id = slurm.NO_VAL
+            selstep.stepid = slurm.NO_VAL
+            selstep.jobid = j
+            slurm.slurm_list_append(query_step_list, selstep);
+
+        query.acct_list = NULL
+        query.associd_list = NULL
+        query.cluster_list = NULL
+        query.cpus_max = 0
+        query.cpus_min = 0
+        query.duplicates = 0
+        query.exitcode = 0
+        query.groupid_list = NULL
+        query.jobname_list = NULL
+        query.nodes_max = 0
+        query.nodes_min = 0
+        query.partition_list = NULL
+        query.qos_list = NULL
+        query.resv_list = NULL
+        query.resvid_list = NULL
+        query.state_list = NULL
+        query.step_list = query_step_list
+        query.timelimit_max = 0
+        query.timelimit_min = 0
+        query.usage_end = endtime
+        query.usage_start = starttime
+        query.used_nodes = NULL
+        query.userid_list = NULL
+        query.wckey_list = NULL
+        query.without_steps = 0
+        query.without_usage_truncation = 1
+
+        dbconn = slurm.slurmdb_connection_get()
+        JOBSList = slurm.slurmdb_jobs_get(dbconn, <slurm.slurmdb_job_cond_t*>&query)
+        slurm.slurm_list_destroy(query_step_list)
+
+        if JOBSList is NULL:
+            apiError = slurm.slurm_get_errno()
+            raise ValueError(slurm.slurm_strerror(apiError), apiError)
+
+        slurm.slurmdb_connection_close(&dbconn)
+
+
+        listNum = slurm.slurm_list_count(JOBSList)
+        iters = slurm.slurm_list_iterator_create(JOBSList)
+
+        for i in range(listNum):
+            job = <slurm.slurmdb_job_rec_t *>slurm.slurm_list_next(iters)
+
+            JOBS_info = {}
+            if job is not NULL:
+                jobid = job.jobid
+                JOBS_info[u'account'] = slurm.stringOrNone(job.account, '')
+                JOBS_info[u'allocated_gres'] = slurm.stringOrNone(job.alloc_gres, '')
+                JOBS_info[u'allocated_nodes'] = job.alloc_nodes
+                JOBS_info[u'array_job_id'] = job.array_job_id
+                JOBS_info[u'array_max_tasks'] = job.array_max_tasks
+                JOBS_info[u'array_task_id'] = job.array_task_id
+                JOBS_info[u'array_task_str'] = slurm.stringOrNone(job.array_task_str, '')
+                JOBS_info[u'associd'] = job.associd
+                JOBS_info[u'blockid'] = slurm.stringOrNone(job.blockid, '')
+                JOBS_info[u'cluster'] = slurm.stringOrNone(job.cluster, '')
+                JOBS_info[u'derived_ec'] = job.derived_ec
+                JOBS_info[u'derived_es'] = slurm.stringOrNone(job.derived_es, '')
+                JOBS_info[u'elapsed'] = job.elapsed
+                JOBS_info[u'eligible'] = job.eligible
+                JOBS_info[u'end'] = job.end
+                JOBS_info[u'exit_code'] = job.exitcode
+                JOBS_info[u'gid'] = job.gid
+                JOBS_info[u'jobid'] = job.jobid
+                JOBS_info[u'jobname'] = slurm.stringOrNone(job.jobname, '')
+                JOBS_info[u'lft'] = job.lft
+                JOBS_info[u'partition'] = slurm.stringOrNone(job.partition, '')
+                JOBS_info[u'nodes'] = slurm.stringOrNone(job.nodes, '')
+                JOBS_info[u'priority'] = job.priority
+                JOBS_info[u'qosid'] = job.qosid
+                JOBS_info[u'req_cpus'] = job.req_cpus
+                JOBS_info[u'req_gres'] = slurm.stringOrNone(job.req_gres, '')
+                JOBS_info[u'req_mem'] = job.req_mem
+                JOBS_info[u'requid'] = job.requid
+                JOBS_info[u'resvid'] = job.resvid
+                JOBS_info[u'resv_name'] = slurm.stringOrNone(job.resv_name,'')
+                JOBS_info[u'show_full'] = job.show_full
+                JOBS_info[u'start'] = job.start
+                JOBS_info[u'state'] = job.state
+                job_statistics = <slurm.slurmdb_stats_t> job.stats
+                JOBS_info[u'stat_actual_cpufreq'] = job_statistics.act_cpufreq
+                JOBS_info[u'stat_cpu_ave'] = job_statistics.cpu_ave
+                JOBS_info[u'stat_consumed_energy'] = job_statistics.consumed_energy
+                JOBS_info[u'stat_cpu_min'] = job_statistics.cpu_min
+                JOBS_info[u'stat_cpu_min_nodeid'] = job_statistics.cpu_min_nodeid
+                JOBS_info[u'stat_cpu_min_taskid'] = job_statistics.cpu_min_taskid
+                JOBS_info[u'stat_disk_read_ave'] = job_statistics.disk_read_ave
+                JOBS_info[u'stat_disk_read_max'] = job_statistics.disk_read_max
+                JOBS_info[u'stat_disk_read_max_nodeid'] = job_statistics.disk_read_max_nodeid
+                JOBS_info[u'stat_disk_read_max_taskid'] = job_statistics.disk_read_max_taskid
+                JOBS_info[u'stat_disk_write_ave'] = job_statistics.disk_write_ave
+                JOBS_info[u'stat_disk_write_max'] = job_statistics.disk_write_max
+                JOBS_info[u'stat_disk_write_max_nodeid'] = job_statistics.disk_write_max_nodeid
+                JOBS_info[u'stat_disk_write_max_taskid'] = job_statistics.disk_write_max_taskid
+                JOBS_info[u'stat_pages_ave'] = job_statistics.pages_ave
+                JOBS_info[u'stat_pages_max'] = job_statistics.pages_max
+                JOBS_info[u'stat_pages_max_nodeid'] = job_statistics.pages_max_nodeid
+                JOBS_info[u'stat_pages_max_taskid'] = job_statistics.pages_max_taskid
+                JOBS_info[u'stat_rss_ave'] = job_statistics.rss_ave
+                JOBS_info[u'stat_rss_max'] = job_statistics.rss_max
+                JOBS_info[u'stat_rss_max_nodeid'] = job_statistics.rss_max_nodeid
+                JOBS_info[u'stat_rss_max_taskid'] = job_statistics.rss_max_taskid
+                JOBS_info[u'stat_vsize_ave'] = job_statistics.vsize_ave
+                JOBS_info[u'stat_vsize_max'] = job_statistics.vsize_max
+                JOBS_info[u'stat_vize_max_nodeid'] = job_statistics.vsize_max_nodeid
+                JOBS_info[u'stat_vsize_max_taskid'] = job_statistics.vsize_max_taskid
+                JOBS_info[u'steps'] = "Not filled, string should be handled"
+                JOBS_info[u'submit'] = job.submit
+                JOBS_info[u'suspended'] = job.suspended
+                JOBS_info[u'sys_cpu_sec'] = job.sys_cpu_sec
+                JOBS_info[u'sys_cpu_usec'] = job.sys_cpu_usec
+                JOBS_info[u'timelimit'] = job.timelimit
+                JOBS_info[u'tot_cpu_sec'] = job.tot_cpu_sec
+                JOBS_info[u'tot_cpu_usec'] = job.tot_cpu_usec
+                JOBS_info[u'track_steps'] = job.track_steps
+                JOBS_info[u'tres_alloc_str'] = slurm.stringOrNone(job.tres_alloc_str,'')
+                JOBS_info[u'tres_req_str'] = slurm.stringOrNone(job.tres_req_str,'')
+                JOBS_info[u'uid'] = job.uid
+                JOBS_info[u'used_gres'] = slurm.stringOrNone(job.used_gres, '')
+                JOBS_info[u'user'] = slurm.stringOrNone(job.user,'')
+                JOBS_info[u'user_cpu_sec'] = job.user_cpu_sec
+                JOBS_info[u'user_cpu_sec'] = job.user_cpu_usec
+                JOBS_info[u'wckey'] = slurm.stringOrNone(job.wckey, '')
+                JOBS_info[u'wckeyid'] = job.wckeyid
+                J_dict[jobid] = JOBS_info
+
+        slurm.slurm_list_iterator_destroy(iters)
+        slurm.slurm_list_destroy(JOBSList)
+        return J_dict
+
+#
+# slurmdbd Reservations Class
+#
+cdef class slurmdb_reservations:
+    u"""Class to access Slurmdbd reservations information."""
+
+    cdef:
+        slurm.slurmdb_reservation_cond_t *reservation_cond
+        void *dbconn
+        dict _RSVDict
+        slurm.List _resvList
+
+    def __cinit__(self):
+        self.dbconn = <void *>NULL
+        self._RSVDict = {}
+        self.reservation_cond = <slurm.slurmdb_reservation_cond_t *>NULL
+
+    def __dealloc__(self):
+        self.__destroy()
+
+    cpdef __destroy(self):
+        u"""Destructor method."""
+        self._RSVDict = {}
+        if self.reservation_cond != NULL:
+            slurm.slurmdb_destroy_reservation_cond(self.reservation_cond)
+
+    def set_reservation_condition(self, start_time, end_time):
+        u"""Limit the next get() call to reservations that start after and before a certain time.
+
+        :param start_time: Select reservations that start after this timestamp
+        :param end_time: Select reservations that end before this timestamp
+        """
+        self.__set_reservation_condition(start_time, end_time)
+
+    cpdef __set_reservation_condition(self, slurm.time_t start_time, slurm.time_t end_time):
+        if self.reservation_cond == NULL:
+            self.reservation_cond = <slurm.slurmdb_reservation_cond_t *>slurm.xmalloc(sizeof(slurm.slurmdb_reservation_cond_t))
+        if self.reservation_cond != NULL:
+            self.reservation_cond.with_usage = 1
+            self.reservation_cond.time_start = <slurm.time_t>start_time
+            self.reservation_cond.time_end = <slurm.time_t>end_time
+        else:
+            raise MemoryError()
+
+    cpdef int __load(self) except? -1:
+        cdef:
+            int apiError = 0
+            void* dbconn = slurm.slurmdb_connection_get()
+            slurm.List resvList = slurm.slurmdb_reservations_get(dbconn, self.reservation_cond)
+
+        if resvList is NULL:
+            apiError = slurm.slurm_get_errno()
+            raise ValueError(slurm.slurm_strerror(apiError), apiError)
+        else:
+            self._resvList = resvList
+
+        slurm.slurmdb_connection_close(&dbconn)
+        return 0
+
+    def get(self):
+        u"""Get slurm reservations information.
+
+        :returns: Dictionary whose keys are the reservations ids
+        :rtype: `dict`
+        """
+        self.__load()
+        self.__get()
+        return self._RSVDict
+
+    cpdef __get(self):
+        cdef:
+            slurm.List reservations_list = NULL
+            slurm.ListIterator iters = NULL
+            int i = 0
+            int listNum = 0
+            dict R_dict = {}
+
+        if self._resvList is not NULL:
+            listNum = slurm.slurm_list_count(self._resvList)
+            iters = slurm.slurm_list_iterator_create(self._resvList)
+            for i in range(listNum):
+                reservation = <slurm.slurmdb_reservation_rec_t *>slurm.slurm_list_next(iters)
+
+                # RESERVATIONS infos
+                resv_info = {}
+                if reservation is not NULL:
+                    reservation_id = reservation.id
+                    resv_info[u'name'] = slurm.stringOrNone(reservation.name, '')
+                    resv_info[u'nodes'] = slurm.stringOrNone(reservation.nodes, '')
+                    resv_info[u'node_index'] = slurm.stringOrNone(reservation.node_inx, '')
+                    resv_info[u'associations'] = slurm.stringOrNone(reservation.assocs, '')
+                    resv_info[u'cluster'] = slurm.stringOrNone(reservation.cluster, '')
+                    resv_info[u'tres_str'] = slurm.stringOrNone(reservation.tres_str, '')
+                    resv_info[u'reservation_id'] = reservation.id
+                    resv_info[u'time_start'] = reservation.time_start
+                    resv_info[u'time_start_prev'] = reservation.time_start_prev
+                    resv_info[u'time_end'] = reservation.time_end
+                    resv_info[u'flags'] = reservation.flags
+                    if reservation.tres_list != NULL:
+                        num_tres = slurm.slurm_list_count(reservation.tres_list)
+                        tres_iters = slurm.slurm_list_iterator_create(reservation.tres_list)
+                        tres_dict = {}
+                        resv_info[u'num_tres'] = num_tres
+                        for j in range(num_tres):
+                            tres = <slurm.slurmdb_tres_rec_t *>slurm.slurm_list_next(tres_iters)
+                            if tres is not NULL:
+                                tmp_tres_dict = {}
+                                tres_id = tres.id
+                                if (tres.name is not NULL):
+                                    tmp_tres_dict[u'name'] = slurm.stringOrNone(tres.name,'')
+                                if (tres.type is not NULL):
+                                    tmp_tres_dict[u'type'] = slurm.stringOrNone(tres.type,'')
+                                tmp_tres_dict[u'rec_count'] = tres.rec_count
+                                tmp_tres_dict[u'count'] = tres.count
+                                tmp_tres_dict[u'tres_id'] = tres.id
+                                tmp_tres_dict[u'alloc_secs'] = tres.alloc_secs
+                                tres_dict[tres_id] = tmp_tres_dict
+                        resv_info[u'tres_list'] = tres_dict
+                        slurm.slurm_list_iterator_destroy(tres_iters)
+                    R_dict[reservation_id] = resv_info
+            slurm.slurm_list_iterator_destroy(iters)
+            slurm.slurm_list_destroy(self._resvList)
+        self._RSVDict = R_dict
+
+#
+# slurmdbd clusters Class
+#
+cdef class slurmdb_clusters:
+    u"""Class to access Slurmdbd Clusters information."""
+
+    cdef:
+        slurm.slurmdb_cluster_cond_t *cluster_cond
+        void *dbconn
+        dict _CLUSTERSDict
+        slurm.List _CLUSTERSList
+
+    def __cinit__(self):
+        self.dbconn = <void *>NULL
+        self._CLUSTERSDict = {}
+        self.cluster_cond = <slurm.slurmdb_cluster_cond_t *>NULL
+
+    def __dealloc__(self):
+        self.__destroy()
+
+    cpdef __destroy(self):
+        u"""Destructor method."""
+        self._CLUSTERSDict = {}
+        if self.cluster_cond != NULL:
+            slurm.slurmdb_destroy_cluster_cond(self.cluster_cond)
+
+    def set_cluster_condition(self, start_time, end_time):
+        u"""Limit the next get() call to clusters that existed after and before a certain time.
+
+        :param start_time: Select clusters that existed after this timestamp
+        :param end_time: Select clusters that existed before this timestamp
+        """
+        self.__set_cluster_condition(start_time, end_time)
+
+    cpdef __set_cluster_condition(self, slurm.time_t start_time, slurm.time_t end_time):
+        if self.cluster_cond == NULL:
+            self.cluster_cond = <slurm.slurmdb_cluster_cond_t *>slurm.xmalloc(sizeof(slurm.slurmdb_cluster_cond_t))
+        if self.cluster_cond != NULL:
+            slurm.slurmdb_init_cluster_cond(self.cluster_cond, 0)
+            self.cluster_cond.with_deleted = 1
+            self.cluster_cond.with_usage = 1
+            self.cluster_cond.usage_start = <slurm.time_t>start_time
+            self.cluster_cond.usage_end = <slurm.time_t>end_time
+        else:
+            raise MemoryError()
+
+    cpdef int __load(self) except? -1:
+        cdef:
+            int apiError = 0
+            void* dbconn = slurm.slurmdb_connection_get()
+            slurm.List CLUSTERSList = slurm.slurmdb_clusters_get(dbconn, self.cluster_cond)
+
+        if CLUSTERSList is NULL:
+            apiError = slurm.slurm_get_errno()
+            raise ValueError(slurm.slurm_strerror(apiError), apiError)
+        else:
+            self._CLUSTERSList = CLUSTERSList
+
+        slurm.slurmdb_connection_close(&dbconn)
+        return 0
+
+    def get(self):
+        u"""Get slurm clusters information.
+
+        :returns: Dictionary whose keys are the clusters ids
+        :rtype: `dict`
+        """
+        self.__load()
+        self.__get()
+        return self._CLUSTERSDict
+
+    cpdef __get(self):
+        cdef:
+            slurm.List clusters_list = NULL
+            slurm.ListIterator iters = NULL
+            int i = 0
+            int listNum = 0
+            dict C_dict = {}
+
+        if self._CLUSTERSList is not NULL:
+            listNum = slurm.slurm_list_count(self._CLUSTERSList)
+            iters = slurm.slurm_list_iterator_create(self._CLUSTERSList)
+            for i in range(listNum):
+                cluster = <slurm.slurmdb_cluster_rec_t *>slurm.slurm_list_next(iters)
+
+                # CLUSTERS infos
+                CLUSTERS_info = {}
+                if cluster is not NULL:
+                    cluster_name = cluster.name
+                    CLUSTERS_info[u'name'] = slurm.stringOrNone(cluster.name, '')
+                    CLUSTERS_info[u'nodes'] = slurm.stringOrNone(cluster.nodes, '')
+                    CLUSTERS_info[u'control_host'] = slurm.stringOrNone(cluster.control_host, '')
+                    CLUSTERS_info[u'tres'] = slurm.stringOrNone(cluster.tres_str, '')
+                    CLUSTERS_info[u'control_port'] = cluster.control_port
+                    CLUSTERS_info[u'rpc_version'] = cluster.rpc_version
+                    CLUSTERS_info[u'plugin_id_select'] = cluster.plugin_id_select
+                    CLUSTERS_info[u'flags'] = cluster.flags
+                    CLUSTERS_info[u'dimensions'] = cluster.dimensions
+                    CLUSTERS_info[u'classification'] = cluster.classification
+                    if cluster.accounting_list != NULL:
+                        num_acct = slurm.slurm_list_count(cluster.accounting_list)
+                        acct_iters = slurm.slurm_list_iterator_create(cluster.accounting_list)
+                        acct_dict = {}
+                        CLUSTERS_info[u'num_acct'] = num_acct
+                        for j in range(num_acct):
+                            acct_tres = <slurm.slurmdb_cluster_accounting_rec_t *>slurm.slurm_list_next(acct_iters)
+                            if acct_tres is not NULL:
+                                acct_tres_dict = {}
+                                acct_tres_id = acct_tres_rec.id
+                                acct_tres_rec = <slurm.slurmdb_tres_rec_t>acct_tres.tres_rec
+                                if (acct_tres_rec.name is not NULL):
+                                    acct_tres_dict[u'name'] = slurm.stringOrNone(acct_tres_rec.name,'')
+                                if (acct_tres_rec.type is not NULL):
+                                    acct_tres_dict[u'type'] = slurm.stringOrNone(acct_tres_rec.type,'')
+                                acct_tres_dict[u'rec_count'] = acct_tres_rec.rec_count
+                                acct_tres_dict[u'count'] = acct_tres_rec.count
+                                acct_tres_dict[u'alloc_secs'] = acct_tres.alloc_secs
+                                acct_tres_dict[u'down_secs'] = acct_tres.down_secs
+                                acct_tres_dict[u'idle_secs'] = acct_tres.idle_secs
+                                acct_tres_dict[u'resv_secs'] = acct_tres.resv_secs
+                                acct_tres_dict[u'pdown_secs'] = acct_tres.pdown_secs
+                                acct_tres_dict[u'over_secs'] = acct_tres.over_secs
+                                acct_tres_dict[u'period_start'] = acct_tres.period_start
+                                acct_dict[acct_tres_id] = acct_tres_dict
+                        CLUSTERS_info[u'accounting'] = acct_dict
+                        slurm.slurm_list_iterator_destroy(acct_iters)
+                    C_dict[cluster_name] = CLUSTERS_info
+
+            slurm.slurm_list_iterator_destroy(iters)
+            slurm.slurm_list_destroy(self._CLUSTERSList)
+        self._CLUSTERSDict = C_dict
+
+
+#
+# slurmdbd Events Class
+#
+cdef class slurmdb_events:
+    u"""Class to access Slurmdbd events information."""
+
+    cdef:
+        slurm.slurmdb_event_cond_t *event_cond
+        void *dbconn
+        dict _EVENTSDict
+        slurm.List _EVENTSList
+
+    def __cinit__(self):
+        self.dbconn = <void *>NULL
+        self._EVENTSDict = {}
+        self.event_cond = <slurm.slurmdb_event_cond_t *>NULL
+
+    def __dealloc__(self):
+        self.__destroy()
+
+    cpdef __destroy(self):
+        u"""Destructor method."""
+        self._EVENTSDict = {}
+        if self.event_cond != NULL:
+            slurm.slurmdb_destroy_event_cond(self.event_cond)
+
+    def set_event_condition(self, start_time, end_time):
+        u"""Limit the next get() call to conditions that existed after and before a certain time.
+
+        :param start_time: Select conditions that existed after this timestamp
+        :param end_time: Select conditions that existed before this timestamp
+        """
+        self.__set_event_condition(start_time, end_time)
+
+    cpdef __set_event_condition(self, slurm.time_t start_time, slurm.time_t end_time):
+        if self.event_cond == NULL:
+            self.event_cond = <slurm.slurmdb_event_cond_t *>slurm.xmalloc(sizeof(slurm.slurmdb_event_cond_t))
+        if self.event_cond != NULL:
+            ##self.event_cond.with_usage = 1
+            self.event_cond.period_start = <slurm.time_t>start_time
+            self.event_cond.period_end = <slurm.time_t>end_time
+        else:
+            raise MemoryError()
+
+    cpdef int __load(self) except? -1:
+        cdef:
+            int apiError = 0
+            void* dbconn = slurm.slurmdb_connection_get()
+            slurm.List EVENTSList = slurm.slurmdb_events_get(dbconn, self.event_cond)
+
+        if EVENTSList is NULL:
+            apiError = slurm.slurm_get_errno()
+            raise ValueError(slurm.slurm_strerror(apiError), apiError)
+        else:
+            self._EVENTSList = EVENTSList
+
+        slurm.slurmdb_connection_close(&dbconn)
+        return 0
+
+    def get(self):
+        u"""Get slurm events information.
+
+        :returns: Dictionary whose keys are the events ids
+        :rtype: `dict`
+        """
+        self.__load()
+        self.__get()
+        return self._EVENTSDict
+
+    cpdef __get(self):
+        cdef:
+            slurm.List events_list = NULL
+            slurm.ListIterator iters = NULL
+            int i = 0
+            int listNum = 0
+            dict E_dict = {}
+
+        if self._EVENTSList is not NULL:
+            listNum = slurm.slurm_list_count(self._EVENTSList)
+            iters = slurm.slurm_list_iterator_create(self._EVENTSList)
+            for i in range(listNum):
+                event = <slurm.slurmdb_event_rec_t *>slurm.slurm_list_next(iters)
+
+                # EVENTS infos
+                EVENTS_info = {}
+                if event is not NULL:
+                    event_id = event.period_start
+                    EVENTS_info[u'cluster'] = slurm.stringOrNone(event.cluster, '')
+                    EVENTS_info[u'cluster_nodes'] = slurm.stringOrNone(event.cluster_nodes, '')
+                    EVENTS_info[u'node_name'] = slurm.stringOrNone(event.node_name, '')
+                    EVENTS_info[u'reason'] = slurm.stringOrNone(event.reason, '')
+                    EVENTS_info[u'tres_str'] = slurm.stringOrNone(event.tres_str, '')
+                    EVENTS_info[u'event_type'] = event.event_type
+                    EVENTS_info[u'time_start'] = event.period_start
+                    EVENTS_info[u'time_end'] = event.period_end
+                    EVENTS_info[u'tres_str'] = event.tres_str
+                    EVENTS_info[u'state'] = event.state
+                    EVENTS_info[u'reason_uid'] = event.reason_uid
+                    E_dict[event_id] = EVENTS_info
+            slurm.slurm_list_iterator_destroy(iters)
+            slurm.slurm_list_destroy(self._EVENTSList)
+        self._EVENTSDict = E_dict
 
 #
 # Helper functions to convert numerical States
@@ -5174,7 +5713,7 @@ def get_partition_state(uint16_t inx):
         elif inx == PARTITION_DOWN:
             state = "DOWN"
         elif inx == PARTITION_INACTIVE:
-            stats = "INACTIVE"
+            state = "INACTIVE"
         elif inx == PARTITION_DRAIN:
             state = "DRAIN"
         else:

--- a/pyslurm/slurm.pxd
+++ b/pyslurm/slurm.pxd
@@ -2105,7 +2105,269 @@ cdef extern from 'slurm/slurm.h' nogil:
 #
 
 cdef extern from 'slurm/slurmdb.h' nogil:
+    ctypedef struct slurmdb_cluster_cond:
+        uint16_t classification
+        List cluster_list
+        uint32_t flags
+        List plugin_id_select_list
+        List rpc_version_list
+        time_t usage_end
+        time_t usage_start
+        uint16_t with_deleted
+        uint16_t with_usage
 
+    ctypedef slurmdb_cluster_cond slurmdb_cluster_cond_t
+
+    ctypedef struct slurmdb_tres_rec:
+        uint64_t alloc_secs
+        uint32_t rec_count
+        uint64_t count
+        uint32_t id
+        char *name
+        char *type
+
+    ctypedef slurmdb_tres_rec slurmdb_tres_rec_t
+
+    ctypedef struct slurmdb_cluster_accounting_rec:
+        uint64_t alloc_secs
+        uint64_t down_secs
+        uint64_t idle_secs
+        uint64_t over_secs
+        uint64_t pdown_secs
+        time_t period_start
+        uint64_t resv_secs
+        slurmdb_tres_rec_t tres_rec
+
+    ctypedef slurmdb_cluster_accounting_rec slurmdb_cluster_accounting_rec_t
+
+    ctypedef struct slurmdb_assoc_usage:
+        List children_list
+        uint64_t *grp_used_tres
+        uint64_t *grp_used_tres_run_secs
+        double grp_used_wall
+        double fs_factor
+        uint32_t level_shares
+#        slurmdb_assoc_rec_t *parent_assoc_ptr
+#        slurmdb_assoc_rec_t *fs_assoc_ptr # need some definition
+        double shares_norm
+        uint32_t tres_cnt
+        long double usage_efctv
+        long double usage_norm
+        long double usage_raw
+        long double *usage_tres_raw
+        uint32_t used_jobs
+        uint32_t used_submit_jobs
+        long double level_fs
+        bitstr_t *valid_qos
+
+    ctypedef slurmdb_assoc_usage slurmdb_assoc_usage_t
+
+    ctypedef struct slurmdb_assoc_rec:
+        List accounting_list
+        char *acct
+        slurmdb_assoc_rec *assoc_next
+        slurmdb_assoc_rec *assoc_next_id
+        char *cluster
+        uint32_t def_qos_id
+        uint32_t grp_jobs
+        uint32_t grp_submit_jobs
+        char *grp_tres
+        uint64_t *grp_tres_ctld
+        char *grp_tres_min
+        uint64_t *grp_tres_mins_ctld
+        char *grp_tres_run_mins
+        uint64_t *grp_tres_run_mins_ctld
+        uint32_t grp_wall
+        uint32_t id
+        uint16_t is_def
+        uint32_t lft
+        uint32_t max_jobs
+        uint32_t max_submit_jobs
+        char *max_tres_mins_pj
+        uint64_t *max_tres_mins_ctldi
+        char *max_tres_run_mins
+        uint64_t *max_tres_run_mins_ctld
+        char *max_tres_pj
+        uint64_t *max_tres_ctld
+        char *max_tres_pn
+        uint64_t *max_tres_pn_ctld
+        uint32_t max_wall_pj
+        char *parent_acct
+        uint32_t parent_id
+        char *partition
+        List qos_list
+        uint32_t rgt
+        uint32_t shares_raw
+        uint32_t uid
+        slurmdb_assoc_usage_t *usage
+        char *user
+
+    ctypedef slurmdb_assoc_rec slurmdb_assoc_rec_t
+
+    ctypedef struct slurmdb_cluster_rec:
+        List accounting_list
+        uint16_t classification
+        char *control_host
+        uint32_t control_port
+        uint16_t dimensions
+        int *dim_size
+        uint32_t flags
+        char *name
+        char *nodes
+        uint32_t plugin_id_select
+        slurmdb_assoc_rec_t *root_assoc #It is not required to support now
+        uint16_t rpc_version
+        char *tres_str
+
+    ctypedef slurmdb_cluster_rec slurmdb_cluster_rec_t
+
+    ctypedef struct slurmdb_job_cond:
+        List acct_list
+        List associd_list
+        List cluster_list
+        uint32_t cpus_max
+        uint32_t cpus_min
+        uint16_t duplicates
+        int32_t exitcode
+        List groupid_list
+        List jobname_list
+        uint32_t nodes_max
+        uint32_t nodes_min
+        List partition_list
+        List qos_list
+        List resv_list
+        List resvid_list
+        List state_list
+        List step_list
+        uint32_t timelimit_max
+        uint32_t timelimit_min
+        time_t usage_end
+        time_t usage_start
+        char *used_nodes
+        List userid_list
+        List wckey_list
+        uint16_t without_steps
+        uint16_t without_usage_truncation
+
+    ctypedef slurmdb_job_cond slurmdb_job_cond_t
+
+    ctypedef struct slurmdb_stats:
+        double act_cpufreq
+        double cpu_ave
+        double consumed_energy
+        uint32_t cpu_min
+        uint32_t cpu_min_nodeid
+        uint32_t cpu_min_taskid
+        double disk_read_ave
+        double disk_read_max
+        uint32_t disk_read_max_nodeid
+        uint32_t disk_read_max_taskid
+        double disk_write_ave
+        double disk_write_max
+        uint32_t disk_write_max_nodeid
+        uint32_t disk_write_max_taskid
+        double pages_ave
+        uint64_t pages_max
+        uint32_t pages_max_nodeid
+        uint32_t pages_max_taskid
+        double rss_ave
+        uint64_t rss_max
+        uint32_t rss_max_nodeid
+        uint32_t rss_max_taskid
+        double vsize_ave
+        uint64_t vsize_max
+        uint32_t vsize_max_nodeid
+        uint32_t vsize_max_taskid
+
+    ctypedef slurmdb_stats slurmdb_stats_t
+
+    ctypedef struct slurmdb_job_rec:
+        char *account
+        char *alloc_gres
+        uint32_t alloc_nodes
+        uint32_t array_job_id
+        uint32_t array_max_tasks
+        uint32_t array_task_id
+        char *array_task_str
+        uint32_t associd
+        char *blockid
+        char *cluster
+        uint32_t derived_ec
+        char *derived_es
+        uint32_t elapsed
+        time_t eligible
+        time_t end
+        uint32_t exitcode
+        void *first_step_ptr
+        uint32_t gid
+        uint32_t jobid
+        char *jobname
+        uint32_t lft
+        char *partition
+        char *nodes
+        uint32_t priority
+        uint32_t qosid
+        uint32_t req_cpus
+        char *req_gres
+        uint32_t req_mem
+        uint32_t requid
+        uint32_t resvid
+        char *resv_name
+        uint32_t show_full
+        time_t start
+        uint32_t state
+        slurmdb_stats_t stats
+        List steps
+        time_t submit
+        uint32_t suspended
+        uint32_t sys_cpu_sec
+        uint32_t sys_cpu_usec
+        uint32_t timelimit
+        uint32_t tot_cpu_sec
+        uint32_t tot_cpu_usec
+        uint16_t track_steps
+        char *tres_alloc_str
+        char *tres_req_str
+        uint32_t uid
+        char *used_gres
+        char *user
+        uint32_t user_cpu_sec
+        uint32_t user_cpu_usec
+        char *wckey
+        uint32_t wckeyid
+
+    ctypedef slurmdb_job_rec slurmdb_job_rec_t
+
+    # Reservations
+    ctypedef struct slurmdb_reservation_cond:
+        List cluster_list
+        uint16_t flags
+        List id_list
+        List name_list
+        char *nodes
+        time_t time_end
+        time_t time_start
+        uint16_t with_usage
+
+    ctypedef slurmdb_reservation_cond slurmdb_reservation_cond_t
+
+    ctypedef struct slurmdb_reservation_rec:
+        char *assocs
+        char *cluster
+        uint32_t flags
+        uint32_t id
+        char *name
+        char *nodes
+        char *node_inx
+        time_t time_end
+        time_t time_start
+        time_t time_start_prev
+        char *tres_str
+        List tres_list
+
+    ctypedef slurmdb_reservation_rec slurmdb_reservation_rec_t
+
+    # Qos
     ctypedef struct slurmdb_qos_usage_t:
         List job_list
         uint32_t grp_used_jobs
@@ -2168,6 +2430,42 @@ cdef extern from 'slurm/slurmdb.h' nogil:
 
     ctypedef slurmdb_qos_cond slurmdb_qos_cond_t
 
+    # Events
+    ctypedef struct slurmdb_event_cond:
+        List cluster_list
+        uint32_t cpus_max
+        uint32_t cpus_min
+        uint16_t event_type
+        List node_list
+        time_t period_end
+        time_t period_start
+        List reason_list
+        List reason_uid_list
+        List state_list
+
+    ctypedef slurmdb_event_cond slurmdb_event_cond_t
+
+    ctypedef struct slurmdb_event_rec:
+        char *cluster
+        char *cluster_nodes
+        uint16_t event_type
+        char *node_name
+        time_t period_end
+        time_t period_start
+        char *reason
+        uint32_t reason_uid
+        uint16_t state
+        char *tres_str
+
+    ctypedef slurmdb_event_rec slurmdb_event_rec_t
+
+    ctypedef struct slurmdb_selected_step:
+        uint32_t array_task_id
+        uint32_t jobid
+        uint32_t stepid
+
+    ctypedef slurmdb_selected_step slurmdb_selected_step_t
+
     #
     # Accounting Storage
     #
@@ -2187,6 +2485,31 @@ cdef extern from 'slurm/slurmdb.h' nogil:
                                          slurmdb_qos_rec_t *qos)
     cdef extern List slurmdb_qos_remove (void *db_conn, slurmdb_qos_cond_t *qos_cond)
 
+    # jobs accounting C APIs
+    cdef extern List slurmdb_jobs_get(void *db_conn, slurmdb_job_cond_t *job_cond)
+    cdef extern void slurmdb_destroy_job_cond(void *object)
+    cdef extern void slurmdb_destroy_job_rec(void *object)
+    cdef extern void slurmdb_destroy_selected_step(void *object)
+
+    # reservation accounting details
+    cdef extern List slurmdb_reservations_get(void *db_conn,
+                         slurmdb_reservation_cond_t *resv_cond)
+    cdef extern void slurmdb_destroy_reservation_cond(void *object)
+    cdef extern void slurmdb_destroy_reservation_rec(void *object);
+
+    # clusters accounting and report APIs
+    cdef extern List slurmdb_clusters_get(void *db_conn, slurmdb_cluster_cond_t *cluster_cond)
+    cdef extern void slurmdb_init_cluster_cond(slurmdb_cluster_cond_t *cluster, bool free_it)
+    cdef extern void slurmdb_destroy_cluster_cond(void *object)
+    #cdef extern void slurmdb_init_cluster_rec(slurmdb_cluster_rec_t *cluster, bool free_it)
+    cdef extern void slurmdb_destroy_cluster_rec(void *object)
+    #cdef extern void slurmdb_destroy_report_cluster_rec(void *object)
+
+    # event accounting details
+    cdef extern List slurmdb_events_get(void *db_conn,
+                         slurmdb_event_cond_t *resv_cond)
+    cdef extern void slurmdb_destroy_event_cond(void *object)
+    cdef extern void slurmdb_destroy_event_rec(void *object);
 
 #
 # Slurm declarations not in slurm.h


### PR DESCRIPTION
Add basic support for the slurmdb API. You can access cluster, event, job, qos and reservation information. There are only a few filtering options available yet.

This pull request does not resolve completely issue #76, but it is a first step.
