### PR TITLE
Backport UTF8 encoding fix

### DIFF
--- a/pyslurm/slurm.pxd
+++ b/pyslurm/slurm.pxd
@@ -53,7 +53,7 @@ cdef inline stringOrNone(char* value, value2):
 		if value2 is '':
 			return None
 		return u"%s" % value2
-	return u"%s" % value
+	return u"%s" % value.decode('utf-8', 'replace')
 
 cdef inline boolToString(int value):
 	if value == 0:


### PR DESCRIPTION
We hit #71 on an install using the slurm-2.5 branch, and fixed by applying the decode change. This PR would apply the fix for anyone still using slurm-2.5