### PR TITLE
Fix setup.py initialization order so that commandline arguments are honored again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -306,12 +306,6 @@ def parse_setuppy_commands():
         elif "build" in args or "build_ext" in args:
             build()
 
-# Get the list of extensions
-extNames = scandir("pyslurm/")
-
-# Build up the set of Extension objects
-extensions = [makeExtension(name) for name in extNames]
-
 here = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(here, "README.rst")) as f:
@@ -319,6 +313,12 @@ with open(os.path.join(here, "README.rst")) as f:
 
 def setup_package():
     parse_setuppy_commands()
+
+    # Get the list of extensions
+    extNames = scandir("pyslurm/")
+
+    # Build up the set of Extension objects
+    extensions = [makeExtension(name) for name in extNames]
 
     setup(
         name="pyslurm",


### PR DESCRIPTION
Commandline arguments like --slurm-inc=, --slurm-lib=, and --slurm= are ignored in the current,
refactored version of setup.py. This makes it impossible to build pyslurm if slurm is not
installed in the default system location. By changing the initialization order they work again.

The fix will moves the initialization of the build-targets after the command line parsing code and fixes the issue.