### PR TITLE
Add ntasks and cpus_per_task options, fix db_conn in slurmdb_jobs

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -2182,6 +2182,7 @@ cdef class job:
             Job_dict[u'ntasks_per_board'] = self._record.ntasks_per_board
             Job_dict[u'num_cpus'] = self._record.num_cpus
             Job_dict[u'num_nodes'] = self._record.num_nodes
+            Job_dict[u'num_tasks'] = self._record.num_tasks
 
             if self._record.pack_job_id:
                 Job_dict[u'pack_job_id'] = self._record.pack_job_id

--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -5577,9 +5577,6 @@ cdef class slurmdb_jobs:
         self.db_conn = slurm.slurmdb_connection_get()
 
     def __dealloc__(self):
-        self.__free()
-
-    cpdef __free(self):
         slurm.xfree(self.job_cond)
         slurm.slurmdb_connection_close(&self.db_conn)
 

--- a/tests/test-job.py
+++ b/tests/test-job.py
@@ -58,6 +58,7 @@ def test_job_scontrol():
     assert_equals(test_job_info["nice"], int(sctl_dict["Nice"]))
     assert_equals(test_job_info["num_cpus"], int(sctl_dict["NumCPUs"]))
     assert_equals(test_job_info["num_nodes"], int(sctl_dict["NumNodes"]))
+    assert_equals(test_job_info["num_tasks"], int(sctl_dict["NumTasks"]))
     assert_equals(test_job_info["partition"], sctl_dict["Partition"])
     assert_equals(test_job_info["priority"], int(sctl_dict["Priority"]))
     assert_equals(test_job_info["state_reason"], sctl_dict["Reason"])

--- a/tests/test-job.py
+++ b/tests/test-job.py
@@ -7,10 +7,17 @@ from nose.tools import assert_equals, assert_true, assert_false
 
 def test_job_submit():
     """Job: Test job().submit_batch_job()."""
-    test_job = {"wrap": "sleep 3600", "job_name": "pyslurm_test_job"}
+    test_job = {
+        "wrap": "sleep 3600",
+        "job_name": "pyslurm_test_job",
+        "ntasks": 2,
+        "cpus_per_task": 3,
+    }
     test_job_id = pyslurm.job().submit_batch_job(test_job)
     test_job_search = pyslurm.job().find(name="name", val="pyslurm_test_job")
     assert_true(test_job_id in test_job_search)
+    assert_equals(test_job_search["cpus_per_task"], 3)
+    assert_equals(test_job_search["num_tasks"], 2)
 
 
 def test_job_get():


### PR DESCRIPTION
This PR builds on top of #141 

It includes:
- Options for `submit_batch_job`: "ntasks", "cpus_per_task", "min_cpus", "max_cpus", "min_nodes", max_nodes":
  - As I understand it, the `submit_batch_job` method is along the lines of the `_fill_job_desc_from_opts` function in `src/sbatch/sbatch.c` of the Slurm source. Accordingly I adjusted the options involving "ntasks_set" and "cpus_set" which are both pretty much set along with "ntasks" and "cpus_per_task" in the Slurm source.
  - However, "min_nodes" should be set from "nodelist" (as is done in sbatch). Though, I suspect the worst that could happen is that an inconsistent job is declined by Slurm.\
- Fix of the db connection in `slurmdb_jobs`:
  - Use the class-scope `db_conn` and close when the `slurmdb_jobs` instance is freed.
  - Also free the `job_cond` which has been allocated in `__cinit__`.

@giovtorres Regarding the Python 2.6 tests: These seem to fail because of a missing "debug" partition in the CentOS 6 docker containers (newer Python versions use CentOS 7). Couldn't you just drop official Python 2.6 support?