### PR TITLE
Use different Travis env var for PR branch identification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - docker run -d -it -h ernie --name slurm-$SLURM giovtorres/docker-centos7-slurm:$SLURM
 install: true
 before_script:
-  - docker exec slurm-$SLURM git clone --branch=$TRAVIS_BRANCH https://github.com/PySlurm/pyslurm.git
+  - docker exec slurm-$SLURM git clone --branch=$TRAVIS_PULL_REQUEST_BRANCH https://github.com/PySlurm/pyslurm.git
   - docker exec -e PYTHON=$PYTHON -e CYTHON=$CYTHON slurm-$SLURM /pyslurm/scripts/build.sh
   - docker exec -e PYTHON=$PYTHON -e CYTHON=$CYTHON slurm-$SLURM /pyslurm/scripts/configure.sh
 script:


### PR DESCRIPTION
`TRAVIS_BRANCH` for PR builds will use the branch that the PR is trying to merge into, and not the actual PR itself. `TRAVIS_PULL_REQUEST_BRANCH` should fix this.