### PR TITLE
fix python setup.py clean error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class Pyslurm:
             if os.path.isfile(path) and path.endswith(".pyx"):
                 files.append(path.replace(os.path.sep, ".")[:-4])
             elif os.path.isdir(path):
-                scandir(path, files)
+                Pyslurm.scandir(path, files)
 
         return files
 


### PR DESCRIPTION
```
INFO: Clean - checking for objects to clean
INFO: Clean - completed
Traceback (most recent call last):
  File "setup.py", line 344, in <module>
    Pyslurm().setup_package()
  File "setup.py", line 297, in setup_package
    extNames = self.scandir("pyslurm/")
  File "setup.py", line 91, in scandir
    self.scandir(path, files)
```