### PR TITLE
Add tres options for Job Descriptor

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -2836,7 +2836,8 @@ cdef class job:
             desc.mcs_label = mcs_label
 
         if job_opts.get("gres"):
-            desc.gres = job_opts.get("gres")
+            gres = job_opts.get("gres").encode("UTF-8", "replace")
+            desc.gres = gres
 
         return 0
 

--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -2835,6 +2835,9 @@ cdef class job:
             mcs_label = job_opts.get("mcs_label").encode("UTF-8", "replace")
             desc.mcs_label = mcs_label
 
+        if job_opts.get("gres"):
+            desc.gres = job_opts.get("gres")
+
         return 0
 
     cdef int envcount(self, char **env):

--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -2835,9 +2835,9 @@ cdef class job:
             mcs_label = job_opts.get("mcs_label").encode("UTF-8", "replace")
             desc.mcs_label = mcs_label
 
-        if job_opts.get("gres"):
-            gres = job_opts.get("gres").encode("UTF-8", "replace")
-            desc.gres = gres
+        if job_opts.get("tres_per_node"):
+            tres_per_node = job_opts.get("tres_per_node").encode("UTF-8", "replace")
+            desc.tres_per_node = tres_per_node
 
         return 0
 

--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -2835,9 +2835,17 @@ cdef class job:
             mcs_label = job_opts.get("mcs_label").encode("UTF-8", "replace")
             desc.mcs_label = mcs_label
 
+        if job_opts.get("tres_per_job"):
+            tres_per_job = job_opts.get("tres_per_job").encode("UTF-8", "replace")
+            desc.tres_per_job = tres_per_job
+
         if job_opts.get("tres_per_node"):
             tres_per_node = job_opts.get("tres_per_node").encode("UTF-8", "replace")
             desc.tres_per_node = tres_per_node
+
+        if job_opts.get("tres_per_task"):
+            tres_per_task = job_opts.get("tres_per_task").encode("UTF-8", "replace")
+            desc.tres_per_task = tres_per_task
 
         return 0
 

--- a/pyslurm/slurm.pxd
+++ b/pyslurm/slurm.pxd
@@ -827,7 +827,6 @@ cdef extern from 'slurm/slurm.h' nogil:
         char *x11_magic_cookie
         char *x11_target
         uint16_t x11_target_port
-        char *gres
 
     ctypedef job_descriptor job_desc_msg_t
 

--- a/pyslurm/slurm.pxd
+++ b/pyslurm/slurm.pxd
@@ -827,6 +827,7 @@ cdef extern from 'slurm/slurm.h' nogil:
         char *x11_magic_cookie
         char *x11_target
         uint16_t x11_target_port
+        char *gres
 
     ctypedef job_descriptor job_desc_msg_t
 


### PR DESCRIPTION
This PR adds 3 options for job descriptor, exposing this to the Pyslurm batch job API

* tres_per_job
* tres_per_node
* tres_per_task

These 3 parameters substitute the use of `gres` according to this: https://slurm.schedmd.com/SLUG18/cons_tres.pdf [Page 10]