### PR TITLE
Fixes req_mem value in slurmdb_jobs class

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -5177,7 +5177,14 @@ cdef class slurmdb_jobs:
                 JOBS_info[u'qosid'] = job.qosid
                 JOBS_info[u'req_cpus'] = job.req_cpus
                 JOBS_info[u'req_gres'] = slurm.stringOrNone(job.req_gres, '')
-                JOBS_info[u'req_mem'] = job.req_mem
+
+                if job.req_mem & slurm.MEM_PER_CPU:
+                    JOBS_info[u'req_mem'] = job.req_mem & (~slurm.MEM_PER_CPU)
+                    JOBS_info[u'req_mem_per_cpu'] = True
+                else:
+                    JOBS_info[u'req_mem'] = job.req_mem
+                    JOBS_info[u'req_mem_per_cpu'] = False
+
                 JOBS_info[u'requid'] = job.requid
                 JOBS_info[u'resvid'] = job.resvid
                 JOBS_info[u'resv_name'] = slurm.stringOrNone(job.resv_name,'')


### PR DESCRIPTION
Fixes #183

Also added a new boolean entry "req_mem_per_cpu". Otherwise, one wouldn't know if --mem (mem per node) or --mem-per-cpu was used on submission, and I wanted to leave the "req_mem" entry as integer. (in sacct they put either "c" or "n" after the number to indicate which one was used). Thought this might be the best way to do it while at the same time leaving the "req_mem" entry as is.