### PR TITLE
Clarify compatible Slurm version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Overview
 Currently PySlurm is under development to move from it's thin layer on top of
 the Slurm C API to an object orientated interface.
 
-This release is based on Slurm 20.02.
+This release is based on Slurm 20.02.5.
 
 Prerequisites
 *************
@@ -24,7 +24,7 @@ This PySlurm branch has been tested with:
 
 * Cython 0.19.2, and the latest stable
 * Python 2.7, 3.4, 3.5 and 3.6
-* Slurm 20.02
+* Slurm 20.02.5
 
 
 Installation


### PR DESCRIPTION
Pyslurm does not compile against Slurm versions < 20.02.5, but the README just says 20.02.