### PR TITLE
chore: remove Python 2 print function support

### DIFF
--- a/examples/blocks_list.py
+++ b/examples/blocks_list.py
@@ -2,7 +2,6 @@
 """
 Retrieve list of blocked items
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/blocks_list2.py
+++ b/examples/blocks_list2.py
@@ -2,7 +2,6 @@
 """
 Retrieve list of blocked items
 """
-from __future__ import print_function
 
 from time import sleep
 

--- a/examples/cancel_job.py
+++ b/examples/cancel_job.py
@@ -2,7 +2,6 @@
 """
 Cancel a scheduled job
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/checkpoint_job.py
+++ b/examples/checkpoint_job.py
@@ -2,7 +2,6 @@
 """
 Retrieve a jobs checkpoint status
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/controllers.py
+++ b/examples/controllers.py
@@ -2,7 +2,6 @@
 """
 Retrieve list up Slurm controllers
 """
-from __future__ import print_function
 
 import socket
 

--- a/examples/debug_levels.py
+++ b/examples/debug_levels.py
@@ -2,7 +2,6 @@
 """
 How to set Slurm debug level
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/hostlist.py
+++ b/examples/hostlist.py
@@ -2,7 +2,6 @@
 """
 Retrieve Slurm hosts
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/job_test.py
+++ b/examples/job_test.py
@@ -2,7 +2,6 @@
 """
 Class to access/modify Slurm Job Information.
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/jobs_list.py
+++ b/examples/jobs_list.py
@@ -2,7 +2,6 @@
 """
 List Slurm jobs
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/jobsteps_layout.py
+++ b/examples/jobsteps_layout.py
@@ -2,7 +2,6 @@
 """
 Display Slurm jobsteps
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/jobsteps_list.py
+++ b/examples/jobsteps_list.py
@@ -2,7 +2,6 @@
 """
 List steps jobs have gone through
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/licenses.py
+++ b/examples/licenses.py
@@ -2,7 +2,6 @@
 """
 List Slurm licenses
 """
-from __future__ import print_function
 
 
 def display(lic_dict):

--- a/examples/listdb_jobs.py
+++ b/examples/listdb_jobs.py
@@ -16,11 +16,17 @@ def job_display(job):
 
 if __name__ == "__main__":
     try:
-        start = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).strftime("%Y-%m-%dT00:00:00")
-        end = (datetime.datetime.utcnow() + datetime.timedelta(days=1)).strftime("%Y-%m-%dT00:00:00")
+        start = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).strftime(
+            "%Y-%m-%dT00:00:00"
+        )
+        end = (datetime.datetime.utcnow() + datetime.timedelta(days=1)).strftime(
+            "%Y-%m-%dT00:00:00"
+        )
 
         jobs = pyslurm.slurmdb_jobs()
-        jobs_dict = jobs.get(starttime=start.encode('utf-8'), endtime=end.encode('utf-8'))
+        jobs_dict = jobs.get(
+            starttime=start.encode("utf-8"), endtime=end.encode("utf-8")
+        )
         if jobs_dict:
             for key, value in jobs_dict.items():
                 print("{} Job: {}".format("{", key))

--- a/examples/node_list.py
+++ b/examples/node_list.py
@@ -2,7 +2,6 @@
 """
 List Slurm nodes
 """
-from __future__ import print_function
 
 
 def display(node_dict):

--- a/examples/node_update.py
+++ b/examples/node_update.py
@@ -15,8 +15,6 @@ Modify the state of a Node or BG Base Partition
    Some states are not valid on a Blue Gene
 """
 
-from __future__ import print_function
-
 import pyslurm
 
 Node_dict = {

--- a/examples/partition_create.py
+++ b/examples/partition_create.py
@@ -2,7 +2,6 @@
 """
 Create a slurm partition.
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/partition_delete.py
+++ b/examples/partition_delete.py
@@ -2,7 +2,6 @@
 """
 Delete a given slurm partition
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/partition_list.py
+++ b/examples/partition_list.py
@@ -2,7 +2,6 @@
 """
 List Slurm partitions
 """
-from __future__ import print_function
 
 
 def display(part_dict):

--- a/examples/partition_update.py
+++ b/examples/partition_update.py
@@ -2,7 +2,6 @@
 """
 Update a given Slurm partitions
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/reservation_create.py
+++ b/examples/reservation_create.py
@@ -2,7 +2,6 @@
 """
 Create a Slurm reservation
 """
-from __future__ import print_function
 
 import sys
 import time

--- a/examples/reservation_delete.py
+++ b/examples/reservation_delete.py
@@ -2,7 +2,6 @@
 """
 Delete Slurm reservations
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/reservation_list.py
+++ b/examples/reservation_list.py
@@ -2,7 +2,6 @@
 """
 List Slurm reservations
 """
-from __future__ import print_function
 
 import time
 

--- a/examples/reservation_update.py
+++ b/examples/reservation_update.py
@@ -2,7 +2,6 @@
 """
 Update Slurm reservations
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/show-cluster-util.py
+++ b/examples/show-cluster-util.py
@@ -19,7 +19,7 @@ def human_readable(num, suffix="B"):
 
 
 def get_util(nodes):
-    """ Return a tuple of cpu and memory percent values."""
+    """Return a tuple of cpu and memory percent values."""
     all_metrics = {
         "total_cpus_alloc": 0,
         "total_cpus_idle": 0,

--- a/examples/show-cluster-util.py
+++ b/examples/show-cluster-util.py
@@ -2,7 +2,6 @@
 """
 Print cluster utilization.
 """
-from __future__ import print_function
 
 import sys
 

--- a/examples/sjobs.py
+++ b/examples/sjobs.py
@@ -2,7 +2,6 @@
 """
 List Slurm jobs from certain users
 """
-from __future__ import print_function
 
 import sys
 from pwd import getpwnam, getpwuid

--- a/examples/slurm_ctl.py
+++ b/examples/slurm_ctl.py
@@ -2,7 +2,6 @@
 """
 Manipulate Slurm configuration
 """
-from __future__ import print_function
 
 import sys
 

--- a/examples/slurm_node_xml.py
+++ b/examples/slurm_node_xml.py
@@ -2,7 +2,6 @@
 """
 Display Slurm node information in XML
 """
-from __future__ import print_function
 
 import os
 import os.path

--- a/examples/slurm_xml.py
+++ b/examples/slurm_xml.py
@@ -2,7 +2,6 @@
 """
 List Slurm information as XML
 """
-from __future__ import print_function
 
 import socket
 import sys

--- a/examples/stats.py
+++ b/examples/stats.py
@@ -2,7 +2,6 @@
 """
 Display Slurm statistics
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/topo_list.py
+++ b/examples/topo_list.py
@@ -2,7 +2,6 @@
 """
 Display Slurm cluster topology
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/triggers_clear.py
+++ b/examples/triggers_clear.py
@@ -2,7 +2,6 @@
 """
 Remove trigger by trigger ID
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/triggers_list.py
+++ b/examples/triggers_list.py
@@ -2,7 +2,6 @@
 """
 List triggers
 """
-from __future__ import print_function
 
 import pyslurm
 

--- a/examples/triggers_set.py
+++ b/examples/triggers_set.py
@@ -48,8 +48,6 @@ ctypedef struct trigger_info:
     char *   program
 """
 
-from __future__ import print_function
-
 import pyslurm
 
 trigDict = {


### PR DESCRIPTION
This change removes the Python 2 support for print functions. Python 2 is no longer supported.