### PR TITLE
Convert mcs_label from bytes to string if defined

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -3122,11 +3122,7 @@ cdef class node:
                 slurm.stringOrNone(record.gres_used, '')
             )
 
-            if record.mcs_label == NULL:
-                Host_dict[u'mcs_label'] = None
-            else:
-                Host_dict[u'mcs_label'] = record.mcs_label
-
+            Host_dict[u'mcs_label'] = slurm.stringOrNone(record.mcs_label, '')
             Host_dict[u'mem_spec_limit'] = record.mem_spec_limit
             Host_dict[u'name'] = slurm.stringOrNone(record.name, '')
 


### PR DESCRIPTION
When it is defined, the mcs_label on nodes are bytes:

```
# python3
Python 3.6.8 (default, Dec  5 2019, 15:45:45)
[GCC 8.3.1 20191121 (Red Hat 8.3.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyslurm
>>> pyslurm.node().get()['cn1']['mcs_label']
b'label'
>>> type(pyslurm.node().get()['cn1']['mcs_label'])
<class 'bytes'>
```

With this commit, it is converted to a unicode string for easier handling by consumer.

Seen with Slurm 20.02.2 and custom version of pyslurm, but patch applies on current main branch.