### PR TITLE
20.11.8 fixups

### DIFF
--- a/examples/slurm_node_xml.py
+++ b/examples/slurm_node_xml.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         "--dir",
         dest="directory",
         action="store",
-        default=os.getcwd,
+        default=os.getcwd(),
         help="Directory to write data to",
     )
     parser.add_argument(

--- a/pyslurm/slurm.pxd
+++ b/pyslurm/slurm.pxd
@@ -4250,7 +4250,7 @@ cdef inline listOrNone(char* value, sep_char):
     if not sep_char:
         return value.decode("UTF-8", "replace")
 
-    if sep_char == b'':
+    if sep_char == '':
         return value.decode("UTF-8", "replace")
 
     return value.decode("UTF_8", "replace").split(sep_char)
@@ -4260,8 +4260,8 @@ cdef inline stringOrNone(char* value, value2):
     if value is NULL:
         if value2 is '':
             return None
-        return u"%s" % value2
-    return u"%s" % value.decode("UTF-8", "replace")
+        return value2
+    return value.decode("UTF-8", "replace")
 
 
 cdef inline int16orNone(uint16_t value):
@@ -4290,7 +4290,7 @@ cdef inline int16orUnlimited(uint16_t value, return_type):
         if return_type is "int":
             return None
         else:
-            return u"UNLIMITED"
+            return "UNLIMITED"
     else:
         if return_type is "int":
             return value
@@ -4300,8 +4300,8 @@ cdef inline int16orUnlimited(uint16_t value, return_type):
 
 cdef inline boolToString(int value):
     if value == 0:
-        return u'False'
-    return u'True'
+        return 'False'
+    return 'True'
 
 
 cdef extern char **environ


### PR DESCRIPTION
os.getcwd typo and remove remaining Python2 unicode string labels