### PR TITLE
Wait_finished method for job API (regarding #240)

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -2883,6 +2883,18 @@ cdef class job:
         #return "Submitted batch job %s" % job_id
         return job_id
 
+    def wait_finished(self, jobid):
+        """
+        Block until the job given by the jobid finishes.
+        :param jobid: The job id of the slurm job.
+        :returns: None
+        :rtype: `None`
+        """
+        job_info = self.find_id(jobid)
+        while job_info[0]["job_state"] != "COMPLETED":
+            p_time.sleep(5)
+            job_info = self.find_id(jobid)
+
 
 def slurm_pid2jobid(uint32_t JobPID=0):
     """Get the slurm job id from a process id.

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -110,3 +110,35 @@ def test_job_kill():
     # time.sleep(3)
     # test_job_search_after = pyslurm.job().find_id(test_job_id)[0]
     # assert_equals(test_job_search_after.get("job_state"), "FAILED")
+
+
+def test_job_wait_finished():
+    """Job: Test job().wait_finished()."""
+    test_job = {
+        "wrap": "sleep 30",
+        "job_name": "pyslurm_test_job",
+        "ntasks": 1,
+        "cpus_per_task": 1,
+    }
+    test_job_id = pyslurm.job().submit_batch_job(test_job)
+    start_job_state = pyslurm.job().find_id(test_job_id)[0]["job_state"]
+    # wait for the job to finish
+    pyslurm.job().wait_finished(test_job_id)
+    end_job_state = pyslurm.job().find_id(test_job_id)[0]["job_state"]
+    assert start_job_state != "COMPLETED"
+    assert end_job_state == "COMPLETED"
+
+    # test again with another wrap time
+    test_job = {
+        "wrap": "sleep 300",
+        "job_name": "pyslurm_test_job",
+        "ntasks": 1,
+        "cpus_per_task": 1,
+    }
+    test_job_id = pyslurm.job().submit_batch_job(test_job)
+    start_job_state = pyslurm.job().find_id(test_job_id)[0]["job_state"]
+    # wait for the job to finish
+    pyslurm.job().wait_finished(test_job_id)
+    end_job_state = pyslurm.job().find_id(test_job_id)[0]["job_state"]
+    assert start_job_state != "COMPLETED"
+    assert end_job_state == "COMPLETED"


### PR DESCRIPTION
Hello PySlurm developers,
This is my proposal for a method to wait for a job to finish, regarding #240, for the 21.08 version. 

I added the `wait_finished` method to the job class. It is implemented using the `find_id` method of the job class. I also added a test method. I've tested this in the container, as mentioned in the README. At least the test for `wait_finished` passes (although some others are not, which also fail in the version without my changes). Sadly, it turns out the cluster I am able to use, does not run a SLURM version, which I can use with PySlurm. Therefore, I could not test it on the real cluster (but we will get a SLURM update in the next weeks, maybe I will try this again over with a different version).

I'm looking forward to your thoughts and comments!

Best,
Jonathan