### PR TITLE
Fix creating RPM packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,4 @@ graft tests
 graft doc
 graft pyslurm/slurm
 graft pyslurm/pydefines
-include pyslurm/alps_cray.h
+recursive-include pyslurm *.pyx *.px[di] *.h

--- a/README.md
+++ b/README.md
@@ -21,24 +21,18 @@ By default, it is searched inside `/usr/include` for the Header files and in
 For Slurm installations in different locations, you will need to provide
 the corresponding paths to the necessary files.
 
-You can specify these Paths with environment variables, for example:
+You can specify these Paths with environment variables (recommended), for example:
 
 ```shell
 export SLURM_INCLUDE_DIR=/opt/slurm/22.05/include
 export SLURM_LIB_DIR=/opt/slurm/22.05/lib
 ```
 
-Then you can proceed to install PySlurm, for example:
-
-```shell
-pip install pyslurm==22.05.0
-```
-
-Or by cloning the repository:
+Then you can proceed to install PySlurm, for example by cloning the Repository:
 
 ```shell
 git clone https://github.com/PySlurm/pyslurm.git && cd pyslurm
-python setup.py install
+scripts/build.sh
 
 # Or simply with pip
 pip install .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 set -e
 
-###################################
-# Build PySlurm
-###################################
+usage() { echo "Usage: $0 [-j jobs]" 1>&2; exit 1; }
 
-cd pyslurm
-echo "---> Building PySlurm..."
-python$PYTHON setup.py build
+# Option to allow parallel build
+OPT_JOBS=1
 
-echo "---> Installing PySlurm..."
-python$PYTHON setup.py install
+PYTHON_VERSION=3
+
+while getopts ":j:" o; do
+    case "${o}" in
+        j)
+            OPT_JOBS=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+python"$PYTHON_VERSION" setup.py build -j "$OPT_JOBS"
+python"$PYTHON_VERSION" setup.py install

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,17 +5,12 @@ docs=build_sphinx
 [bdist_rpm]
 release = 1
 packager = Giovanni Torres <giovtorres@users.noreply.github.com>
-doc_files = CONTRIBUTORS.rst
-            README.rst
-            THANKS.rst
+doc_files = README.md
             doc/
             examples/
-build_requires = python-devel >= 2.7
-                 Cython >= 0.19
-                 python-sphinx >= 1.1
-                 slurm-devel >= 17.11.5
-                 python-nose
-requires = slurm-slurmd slurm-slurmdbd
+build_requires = python3-devel >= 3.6
+                 slurm-devel >= 22.05.0
+requires = slurm
 use_bzip2 = 1
 
 [build_sphinx]

--- a/setup.py
+++ b/setup.py
@@ -300,9 +300,8 @@ def parse_setuppy_commands():
         cleanup_build()
         return False
 
-    build_cmd = ('install', 'sdist', 'build', 'build_ext', 'build_py',
-                 'build_clib', 'build_scripts', 'bdist_wheel', 'bdist_rpm',
-                 'build_src', 'bdist_egg', 'develop')
+    build_cmd = ('build', 'build_ext', 'build_py', 'build_clib',
+        'build_scripts', 'bdist_wheel', 'build_src', 'bdist_egg', 'develop')
 
     for cmd in build_cmd:
         if cmd in args:
@@ -318,10 +317,14 @@ def setup_package():
     build_it = parse_setuppy_commands()
 
     if build_it:
-        if "sdist" not in sys.argv:
-            parse_slurm_args()
-            slurm_sanity_checks()
-            cythongen()
+        parse_slurm_args()
+        slurm_sanity_checks()
+        cythongen()
+
+    if "install" in sys.argv:
+        parse_slurm_args()
+        slurm_sanity_checks()
+        metadata["ext_modules"] = make_extensions()
 
     setup(**metadata)
 


### PR DESCRIPTION
Fixes the creation of RPM packages (with bdist_rpm) which didn't work because `pyslurm.pyx` wasn't actually included in the tar file that rpmbuild uses to create the RPM - also removes the python-nose, python-sphinx and Cython build-requirements, I think it is fine enough when a virtualenv is used with these installed during build time.

Also makes it so the `python setup.py install` actually only installs again and doesn't do any compilation.
And update the `build.sh` script to allow usage of multiple cores when building (even though there is no real benefit yet, since there is only one file that needs to be compiled right now - but maybe sometime in the future it will help)

Closes #246 