### PR TITLE
Support updating end_time in slurm_update_reservation

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -4314,6 +4314,9 @@ def slurm_update_reservation(dict reservation_dict={}):
         if time_value != -1:
             resv_msg.start_time = time_value
 
+    if reservation_dict.get('end_time'):
+        resv_msg.end_time = reservation_dict['end_time']
+
     if reservation_dict.get('duration'):
         resv_msg.duration = reservation_dict.get('duration')
 


### PR DESCRIPTION
The slurm_update_reservation function seems to ignore end_time updates. This is clearly supported by Slurm, so I assume that this field was forgotten and nobody noticed.

This fix simply adds support for updating the end_time value for a reservation.