### PR TITLE
Fix formatting error for reservation_list example

### DIFF
--- a/examples/reservation_list.py
+++ b/examples/reservation_list.py
@@ -36,7 +36,7 @@ def display(res_dict):
         if res_value["start_time"] <= now <= res_value["end_time"]:
             resv_state = "ACTIVE"
 
-        print(f"\t{'state':-20s} : {resv_state}\n")
+        print(f"\t{'state':<20s} : {resv_state}\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes a typo in the formatting contained in the following example: `examples/reservation_list.py`.