### PR TITLE
Raise ValueError on slurm_update_reservation

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -4372,6 +4372,9 @@ def slurm_update_reservation(dict reservation_dict={}):
         resv_msg.flags = int_value
 
     errCode = slurm.slurm_update_reservation(&resv_msg)
+    if errCode != 0:
+        apiError = slurm.slurm_get_errno()
+        raise ValueError(slurm.stringOrNone(slurm.slurm_strerror(apiError), ''), apiError)
 
     return errCode
 


### PR DESCRIPTION
To be consistent with other functions and methods, we need to raise a ValueError instead of just returning the error code. This also allows client applications to more easily interpret the reason for the error.