### PR TITLE
drop the doc/ directory in doc_files for building rpm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ include = pyslurm, pyslurm.*
 release = 1
 packager = Giovanni Torres <giovtorres@users.noreply.github.com>
 doc_files = README.md
-            doc/
             examples/
 build_requires = python3-devel >= 3.6
                  slurm-devel >= 23.02.0


### PR DESCRIPTION
The `doc` directory is no longer there and it fails building an rpm with this.