### PR TITLE
fix paths in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
-include README.rst
+include README.md
 include COPYING.txt
 graft examples
 graft tests
-graft doc
+graft docs
 graft pyslurm/slurm
 graft pyslurm/pydefines
 recursive-include pyslurm *.pyx *.px[di] *.h


### PR DESCRIPTION
this typo broke debian package building.

Change from README.rst to README.md was in ca4b08f5b679d543ea99e7e0bc095d479ba05ec0
Also fixing doc to docs.