### PR TITLE
Allow db job modification and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased on the [23.2.x](https://github.com/PySlurm/pyslurm/tree/23.2.x) branch
+
+### Added
+
+- Ability to modify Database Jobs
+- New classes to interact with the Partition API
+    - [pyslurm.Partition](https://pyslurm.github.io/23.2/reference/partition/#pyslurm.Partition)
+    - [pyslurm.Partitions](https://pyslurm.github.io/23.2/reference/partition/#pyslurm.Partitions)
+- New attributes for a Database Job:
+    - extra
+    - failed_node
+- Now possible to initialize a pyslurm.db.Jobs collection with existing job
+  ids or pyslurm.db.Job objects
+
+### Fixed
+
+- Fixes a problem that prevented loading specific Jobs from the Database if
+  the following two conditions were met:
+    - no start/end time was specified
+    - the Job was older than a day
+
 ## [23.2.1](https://github.com/PySlurm/pyslurm/releases/tag/v23.2.1) - 2023-05-18
 
 ### Added

--- a/pyslurm/core/job/job.pyx
+++ b/pyslurm/core/job/job.pyx
@@ -48,6 +48,7 @@ from pyslurm.utils.helpers import (
     _getpwall_to_dict,
     instance_to_dict,
     _sum_prop,
+    _get_exit_code,
 )
 
 
@@ -785,35 +786,23 @@ cdef class Job:
 
     @property
     def derived_exit_code(self):
-        if (self.ptr.derived_ec == slurm.NO_VAL
-                or not WIFEXITED(self.ptr.derived_ec)):
-            return None
-
-        return WEXITSTATUS(self.ptr.derived_ec)
+        ec, _ = _get_exit_code(self.ptr.derived_ec)
+        return ec
 
     @property
     def derived_exit_code_signal(self):
-        if (self.ptr.derived_ec == slurm.NO_VAL
-                or not WIFSIGNALED(self.ptr.derived_ec)): 
-            return None
-
-        return WTERMSIG(self.ptr.derived_ec)
+        _, sig = _get_exit_code(self.ptr.derived_ec)
+        return sig
 
     @property
     def exit_code(self):
-        if (self.ptr.exit_code == slurm.NO_VAL
-                or not WIFEXITED(self.ptr.exit_code)):
-            return None
-
-        return WEXITSTATUS(self.ptr.exit_code)
+        ec, _ = _get_exit_code(self.ptr.exit_code)
+        return ec
 
     @property
     def exit_code_signal(self):
-        if (self.ptr.exit_code == slurm.NO_VAL
-                or not WIFSIGNALED(self.ptr.exit_code)):
-            return None
-
-        return WTERMSIG(self.ptr.exit_code)
+        _, sig = _get_exit_code(self.ptr.exit_code)
+        return sig
 
     @property
     def batch_constraints(self):

--- a/pyslurm/db/job.pxd
+++ b/pyslurm/db/job.pxd
@@ -39,6 +39,8 @@ from pyslurm.slurm cimport (
     slurmdb_job_cond_def_start_end,
     slurm_job_state_string,
     slurm_job_reason_string,
+    slurmdb_create_job_rec,
+    slurmdb_job_modify,
 )
 from pyslurm.db.util cimport (
     SlurmList,
@@ -165,6 +167,18 @@ cdef class Job:
     Raises:
         MemoryError: If malloc fails to allocate memory.
 
+    Other Parameters:
+        admin_comment (str):
+            Admin comment for the Job.
+        comment (str):
+            Comment for the Job
+        wckey (str):
+            Name of the WCKey for this Job
+        derived_exit_code (int):
+            Highest exit code of all the Job steps
+        extra (str):
+            Arbitrary string that can be stored with a Job.
+
     Attributes:
         steps (pyslurm.db.JobSteps):
             Steps this Job has
@@ -209,10 +223,14 @@ cdef class Job:
             When the Job became eligible to run, as a unix timestamp
         end_time (int):
             When the Job ended, as a unix timestamp
+        extra (str):
+            Arbitrary string that can be stored with a Job.
         exit_code (int):
             Exit code of the job script or salloc.
         exit_code_signal (int):
             Signal of the exit code for this Job.
+        failed_node (str):
+            Name of the failed node that caused the job to get killed.
         group_id (int):
             ID of the group for this Job
         group_name (str):

--- a/pyslurm/db/job.pxd
+++ b/pyslurm/db/job.pxd
@@ -164,9 +164,6 @@ cdef class Job:
         job_id (int, optional=0):
             An Integer representing a Job-ID.
 
-    Raises:
-        MemoryError: If malloc fails to allocate memory.
-
     Other Parameters:
         admin_comment (str):
             Admin comment for the Job.

--- a/pyslurm/db/job.pyx
+++ b/pyslurm/db/job.pyx
@@ -22,9 +22,8 @@
 # cython: c_string_type=unicode, c_string_encoding=default
 # cython: language_level=3
 
-from os import WIFSIGNALED, WIFEXITED, WTERMSIG, WEXITSTATUS
-from typing import Union
-from pyslurm.core.error import RPCError
+from typing import Union, Any
+from pyslurm.core.error import RPCError, PyslurmError
 from pyslurm.core import slurmctld
 from typing import Any
 from pyslurm.utils.uint import *
@@ -40,6 +39,7 @@ from pyslurm.utils.helpers import (
     uid_to_name,
     nodelist_to_range_str,
     instance_to_dict,
+    _get_exit_code,
 )
 
 
@@ -134,7 +134,6 @@ cdef class JobSearchFilter:
 
         ptr.usage_start = date_to_timestamp(self.start_time)  
         ptr.usage_end = date_to_timestamp(self.end_time)  
-        slurmdb_job_cond_def_start_end(ptr)
         ptr.cpus_min = u32(self.cpus, on_noval=0)
         ptr.cpus_max = u32(self.max_cpus, on_noval=0)
         ptr.nodes_min = u32(self.nodes, on_noval=0)
@@ -190,12 +189,25 @@ cdef class JobSearchFilter:
                 slurm_list_append(ptr.step_list, selected_step)
                 already_added.append(job_id)
 
+        # This must be at the end because it makes decisions based on some
+        # conditions that might be set.
+        slurmdb_job_cond_def_start_end(ptr)
+
 
 cdef class Jobs(dict):
 
-    def __init__(self):
-        # TODO: ability to initialize with existing job objects
-        pass
+    def __init__(self, jobs=None):
+        if isinstance(jobs, dict):
+            self.update(jobs)
+        elif isinstance(jobs, str):
+            joblist = jobs.split(",")
+            self.update({int(job): Job(job) for job in joblist})
+        elif jobs is not None:
+            for job in jobs:
+                if isinstance(job, int):
+                    self[job] = Job(job)
+                else:
+                    self[job.name] = job
 
     @staticmethod
     def load(search_filter=None):
@@ -266,15 +278,106 @@ cdef class Jobs(dict):
 
         return jobs
 
+    @staticmethod
+    def modify(search_filter, db_connection=None, **changes):
+        """Modify Slurm database Jobs.
+
+        Implements the slurm_job_modify RPC.
+
+        Args:
+            search_filter (Union[pyslurm.db.JobSearchFilter, pyslurm.db.Jobs]):
+                A filter to decide which Jobs should be modified.
+            db_connection (pyslurm.db.Connection):
+                A Connection to the slurmdbd. By default, if no connection is
+                supplied, one will automatically be created internally. This
+                means that when the changes were considered successful by the
+                slurmdbd, those modifications will be *automatically
+                committed*.
+
+                If you however decide to provide your own Connection instance
+                (which must be already opened before), and the changes were
+                successful, they will basically be in a kind of "staging
+                area". By the time this function returns, the changes are not
+                actually made.
+                You are then responsible to decide whether the changes should
+                be committed or rolled back by using the respective methods on
+                the connection object. This way, you have a chance to see
+                which Jobs were modified before you commit the changes.
+            **changes (Any):
+                Check the `Other Parameters` Section of [pyslurm.db.Job][] to
+                see what attributes can be modified.
+
+        Returns:
+            list[int]: A list of Jobs that were modified
+
+        Raises:
+            ValueError: When a parsing error occured or the Database
+                connection is not open
+            RPCError: When a failure modifying the Jobs occurred.
+        """
+
+        cdef:
+            Job job = Job(**changes)
+            JobSearchFilter jfilter
+            Connection conn = <Connection>db_connection
+            SlurmList response
+            SlurmListItem response_ptr
+            list out = []
+
+        conn = Connection.open() if not conn else conn
+        if not conn.is_open:
+            raise ValueError("Database connection is not open")
+
+        if isinstance(search_filter, Jobs):
+            job_ids = list(search_filter.keys())
+            jfilter = JobSearchFilter(ids=job_ids)
+        else:
+            jfilter = <JobSearchFilter>search_filter
+
+        jfilter._create()
+        response = SlurmList.wrap(
+                slurmdb_job_modify(conn.ptr, jfilter.ptr, job.ptr))
+
+        if not response.is_null and response.cnt:
+            for response_ptr in response:
+                response_str = cstr.to_unicode(<char*>response_ptr.data)
+                if not response_str:
+                    continue
+
+                # The strings in the list returned above have a structure
+                # like this:
+                #
+                # "<job_id> submitted at <timestamp>"
+                #
+                # We are just interest in the Job-ID, so extract it
+                job_id = response_str.split(" ")[0]
+                if job_id and job_id.isdigit():
+                    out.append(int(job_id))
+
+        elif not response.is_null:
+            # There was no real error, but simply nothing has been modified
+            raise RPCError(msg="Nothing was modified")
+        else:
+            # Autodetects the last slurm error
+            raise RPCError()
+        
+        if not db_connection:
+            # Autocommit if no connection was explicitly specified.
+            conn.commit()
+
+        return out
+
 
 cdef class Job:
 
     def __cinit__(self):
         self.ptr = NULL
 
-    def __init__(self, job_id=0):
+    def __init__(self, job_id=0, **kwargs):
         self._alloc_impl()
         self.ptr.jobid = int(job_id)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
     def __dealloc__(self):
         self._dealloc_impl()
@@ -285,10 +388,7 @@ cdef class Job:
 
     def _alloc_impl(self):
         if not self.ptr:
-            self.ptr = <slurmdb_job_rec_t*>try_xmalloc(
-                    sizeof(slurmdb_job_rec_t))
-            if not self.ptr:
-                raise MemoryError("xmalloc failed for slurmdb_job_rec_t")
+            self.ptr = slurmdb_create_job_rec()
 
     @staticmethod
     cdef Job from_ptr(slurmdb_job_rec_t *in_ptr):
@@ -368,6 +468,20 @@ cdef class Job:
 
         return out
 
+    def modify(self, db_connection=None, **changes):
+        """Modify a Slurm database Job.
+
+        Args:
+            **changes (Any):
+                Check the `Other Parameters` Section of this class to see what
+                attributes can be modified.
+
+        Raises:
+            RPCError: When modifying the Job failed.
+        """
+        cdef JobSearchFilter jfilter = JobSearchFilter(ids=[self.id])
+        Jobs.modify(jfilter, db_connection, **changes)
+
     @property
     def account(self):
         return cstr.to_unicode(self.ptr.account)
@@ -375,6 +489,10 @@ cdef class Job:
     @property
     def admin_comment(self):
         return cstr.to_unicode(self.ptr.admin_comment)
+
+    @admin_comment.setter
+    def admin_comment(self, val):
+        cstr.fmalloc(&self.ptr.admin_comment, val)
 
     @property
     def num_nodes(self):
@@ -441,23 +559,25 @@ cdef class Job:
 
     @property
     def derived_exit_code(self):
-        if (self.ptr.derived_ec == slurm.NO_VAL
-                or not WIFEXITED(self.ptr.derived_ec)):
-            return None
+        ec, _ = _get_exit_code(self.ptr.derived_ec)
+        return ec
 
-        return WEXITSTATUS(self.ptr.derived_ec)
+    @derived_exit_code.setter
+    def derived_exit_code(self, val):
+        self.ptr.derived_ec = int(val)
 
     @property
     def derived_exit_code_signal(self):
-        if (self.ptr.derived_ec == slurm.NO_VAL
-                or not WIFSIGNALED(self.ptr.derived_ec)): 
-            return None
-
-        return WTERMSIG(self.ptr.derived_ec)
+        _, sig = _get_exit_code(self.ptr.derived_ec)
+        return sig
 
     @property
     def comment(self):
         return cstr.to_unicode(self.ptr.derived_es)
+
+    @comment.setter
+    def comment(self, val):
+        cstr.fmalloc(&self.ptr.derived_es, val)
 
     @property
     def elapsed_time(self):
@@ -472,16 +592,28 @@ cdef class Job:
         return _raw_time(self.ptr.end)
 
     @property
+    def extra(self):
+        return cstr.to_unicode(self.ptr.extra)
+
+    @extra.setter
+    def extra(self, val):
+        cstr.fmalloc(&self.ptr.extra, val)
+
+    @property
     def exit_code(self):
-        # TODO
-        return 0
+        ec, _ = _get_exit_code(self.ptr.exitcode)
+        return ec
 
     @property
     def exit_code_signal(self):
-        # TODO
-        return 0
+        _, sig = _get_exit_code(self.ptr.exitcode)
+        return sig
 
     # uint32_t flags
+
+    @property
+    def failed_node(self):
+        return cstr.to_unicode(self.ptr.failed_node)
 
     def group_id(self):
         return u32_parse(self.ptr.gid, zero_is_noval=False)
@@ -593,6 +725,10 @@ cdef class Job:
     def system_comment(self):
         return cstr.to_unicode(self.ptr.system_comment)
 
+    @system_comment.setter
+    def system_comment(self, val):
+        cstr.fmalloc(&self.ptr.system_comment, val)
+
     @property
     def time_limit(self):
         # TODO: Perhaps we should just find out what the actual PartitionLimit
@@ -614,6 +750,10 @@ cdef class Job:
     @property
     def wckey(self):
         return cstr.to_unicode(self.ptr.wckey)
+
+    @wckey.setter
+    def wckey(self, val):
+        cstr.fmalloc(&self.ptr.wckey, val)
 
 #    @property
 #    def wckey_id(self):

--- a/pyslurm/db/job.pyx
+++ b/pyslurm/db/job.pyx
@@ -220,6 +220,9 @@ cdef class Jobs(dict):
                 A search filter that the slurmdbd will apply when retrieving
                 Jobs from the database.
 
+        Returns:
+            (pyslurm.db.Jobs): A Collection of database Jobs.
+
         Raises:
             RPCError: When getting the Jobs from the Database was not
                 sucessful
@@ -291,8 +294,8 @@ cdef class Jobs(dict):
                 A Connection to the slurmdbd. By default, if no connection is
                 supplied, one will automatically be created internally. This
                 means that when the changes were considered successful by the
-                slurmdbd, those modifications will be *automatically
-                committed*.
+                slurmdbd, those modifications will be **automatically
+                committed**.
 
                 If you however decide to provide your own Connection instance
                 (which must be already opened before), and the changes were
@@ -308,12 +311,40 @@ cdef class Jobs(dict):
                 see what attributes can be modified.
 
         Returns:
-            list[int]: A list of Jobs that were modified
+            (list[int]): A list of Jobs that were modified
 
         Raises:
             ValueError: When a parsing error occured or the Database
                 connection is not open
             RPCError: When a failure modifying the Jobs occurred.
+
+        Examples:
+            In its simplest form, you can do something like this:
+
+            >>> import pyslurm
+            >>> search_filter = pyslurm.db.JobSearchFilter(ids=[9999])
+            >>> modified_jobs = pyslurm.db.Jobs.modify(
+            ...             search_filter, comment="A comment for the job")
+            >>> print(modified_jobs)
+            >>> [9999]
+
+            In the above example, the changes will be automatically committed
+            if successful.
+            You can however also control this manually by providing your own
+            connection object:
+
+            >>> import pyslurm
+            >>> search_filter = pyslurm.db.JobSearchFilter(ids=[9999])
+            >>> db_conn = pyslurm.db.Connection.open()
+            >>> modified_jobs = pyslurm.db.Jobs.modify(
+            ...             search_filter, db_conn,
+            ...             comment="A comment for the job")
+            >>> # Now you can first examine which Jobs have been modified
+            >>> print(modified_jobs)
+            >>> [9999]
+            >>> # And then you can actually commit (or even rollback) the
+            >>> # changes
+            >>> db_conn.commit()
         """
 
         cdef:
@@ -407,7 +438,7 @@ cdef class Job:
                 ID of the Job to be loaded.
 
         Returns:
-            (pyslurm.Job): Returns a new Database Job instance
+            (pyslurm.db.Job): Returns a new Database Job instance
 
         Raises:
             RPCError: If requesting the information for the database Job was
@@ -472,6 +503,10 @@ cdef class Job:
         """Modify a Slurm database Job.
 
         Args:
+            db_connection (pyslurm.db.Connection):
+                A slurmdbd connection. See
+                [pyslurm.db.Jobs.modify][pyslurm.db.job.Jobs.modify] for more
+                info
             **changes (Any):
                 Check the `Other Parameters` Section of this class to see what
                 attributes can be modified.

--- a/pyslurm/db/step.pyx
+++ b/pyslurm/db/step.pyx
@@ -31,6 +31,7 @@ from pyslurm.utils.helpers import (
     gid_to_name,
     uid_to_name,
     instance_to_dict,
+    _get_exit_code,
 )
 from pyslurm.core.job.util import cpu_freq_int_to_str
 from pyslurm.core.job.step import humanize_step_id
@@ -120,8 +121,13 @@ cdef class JobStep:
 
     @property
     def exit_code(self):
-        # TODO
-        return None
+        ec, _ = _get_exit_code(self.ptr.exitcode)
+        return ec
+
+    @property
+    def exit_code_signal(self):
+        _, sig = _get_exit_code(self.ptr.exitcode)
+        return sig
 
     @property
     def ntasks(self):

--- a/pyslurm/slurm/extra.pxi
+++ b/pyslurm/slurm/extra.pxi
@@ -266,11 +266,12 @@ cdef extern from *:
 cdef extern char *slurm_hostlist_deranged_string_malloc(hostlist_t hl)
 
 #
-# Slurmdbd functions
+# slurmdb functions
 #
 
 cdef extern void slurmdb_job_cond_def_start_end(slurmdb_job_cond_t *job_cond)
 cdef extern uint64_t slurmdb_find_tres_count_in_string(char *tres_str_in, int id)
+cdef extern slurmdb_job_rec_t *slurmdb_create_job_rec()
 
 #
 # Slurm Partition functions

--- a/pyslurm/utils/helpers.pyx
+++ b/pyslurm/utils/helpers.pyx
@@ -22,6 +22,7 @@
 # cython: c_string_type=unicode, c_string_encoding=default
 # cython: language_level=3
 
+from os import WIFSIGNALED, WIFEXITED, WTERMSIG, WEXITSTATUS
 from grp import getgrgid, getgrnam, getgrall
 from pwd import getpwuid, getpwnam, getpwall
 from os import getuid, getgid
@@ -348,3 +349,16 @@ def _sum_prop(obj, name, startval=0):
             val += v
 
     return val
+
+
+def _get_exit_code(exit_code):
+    exit_state=sig = 0
+    if exit_code != slurm.NO_VAL:
+        if WIFSIGNALED(exit_code):
+            exit_state, sig = 0, WTERMSIG(exit_code)
+        elif WIFEXITED(exit_code):
+            exit_state, sig = WEXITSTATUS(exit_code), 0
+            if exit_state >= 128:
+                exit_state -= 128
+
+    return exit_state, sig

--- a/tests/integration/test_db_job.py
+++ b/tests/integration/test_db_job.py
@@ -56,8 +56,30 @@ def test_parse_all(submit_job):
 
 
 def test_modify(submit_job):
-    # TODO
-    pass
+    job = submit_job()
+    util.wait(5)
+
+    jfilter = pyslurm.db.JobSearchFilter(ids=[job.id])
+    pyslurm.db.Jobs.modify(jfilter, comment="test comment")
+
+    job = pyslurm.db.Job.load(job.id)
+    assert job.comment == "test comment"
+
+
+def test_modify_with_existing_conn(submit_job):
+    job = submit_job()
+    util.wait(5)
+
+    conn = pyslurm.db.Connection.open()
+    jfilter = pyslurm.db.JobSearchFilter(ids=[job.id])
+    pyslurm.db.Jobs.modify(jfilter, conn, comment="test comment")
+
+    job = pyslurm.db.Job.load(job.id)
+    assert job.comment != "test comment"
+
+    conn.commit()
+    job = pyslurm.db.Job.load(job.id)
+    assert job.comment == "test comment"
 
 
 def test_if_steps_exist(submit_job):

--- a/tests/unit/test_db_job.py
+++ b/tests/unit/test_db_job.py
@@ -42,8 +42,32 @@ def test_search_filter():
         job_filter._create()
 
 
-def test_collection_init():
-    # TODO
+def test_create_collection():
+    jobs = pyslurm.db.Jobs("101,102")
+    assert len(jobs) == 2
+    assert 101 in jobs
+    assert 102 in jobs
+    assert jobs[101].id == 101
+    assert jobs[102].id == 102
+
+    jobs = pyslurm.db.Jobs([101, 102])
+    assert len(jobs) == 2
+    assert 101 in jobs
+    assert 102 in jobs
+    assert jobs[101].id == 101
+    assert jobs[102].id == 102
+    
+    jobs = pyslurm.db.Jobs(
+        {
+            101: pyslurm.db.Job(101),
+            102: pyslurm.db.Job(102),
+        }
+    )
+    assert len(jobs) == 2
+    assert 101 in jobs
+    assert 102 in jobs
+    assert jobs[101].id == 101
+    assert jobs[102].id == 102
     assert True
 
 


### PR DESCRIPTION
## Added

- Ability to modify Database Jobs
- New attributes for a Database Job:
    - extra
    - failed_node
- Now possible to initialize a pyslurm.db.Jobs collection with existing job
  ids or pyslurm.db.Job objects

## Fixes

- Fixes a problem that prevented loading specific Jobs from the Database if
  the following two conditions were met:
    - no start/end time was specified
    - the Job was older than a day

## Changes

- create a _get_exit_code helper function to reduce duplicate code in various places when checking for exit-code or exit-signal of a Job or JobStep