### PR TITLE
Implement DB Associations API and a little refactoring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - failed_node
 - Now possible to initialize a pyslurm.db.Jobs collection with existing job
   ids or pyslurm.db.Job objects
+- Added `as_dict` function to all Collections
 
 ### Fixed
 
@@ -25,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the following two conditions were met:
     - no start/end time was specified
     - the Job was older than a day
+
+### Changed
+
+- All Collections (like [pyslurm.Jobs](https://pyslurm.github.io/23.2/reference/job/#pyslurm.Jobs)) inherit from `list` now instead of `dict`
+- `JobSearchFilter` has been renamed to `JobFilter`
 
 ## [23.2.1](https://github.com/PySlurm/pyslurm/releases/tag/v23.2.1) - 2023-05-18
 
@@ -49,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - [pyslurm.RPCError](https://pyslurm.github.io/23.2/reference/exceptions/#pyslurm.RPCError)
 - [Utility Functions](https://pyslurm.github.io/23.2/reference/utilities/#pyslurm.utils)
 
-### Changes
+### Changed
 
 - Completely overhaul the documentation, switch to mkdocs
 - Rework the tests: Split them into unit and integration tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - [pyslurm.db.Job](https://pyslurm.github.io/23.2/reference/db/job/#pyslurm.db.Job)
     - [pyslurm.db.Jobs](https://pyslurm.github.io/23.2/reference/db/job/#pyslurm.db.Jobs)
     - [pyslurm.db.JobStep](https://pyslurm.github.io/23.2/reference/db/jobstep/#pyslurm.db.JobStep)
-    - [pyslurm.db.JobSearchFilter](https://pyslurm.github.io/23.2/reference/db/jobsearchfilter/#pyslurm.db.JobSearchFilter)
+    - [pyslurm.db.JobFilter](https://pyslurm.github.io/23.2/reference/db/jobsearchfilter/#pyslurm.db.JobFilter)
 - Classes to interact with the Node API
     - [pyslurm.Node](https://pyslurm.github.io/23.2/reference/node/#pyslurm.Node)
     - [pyslurm.Nodes](https://pyslurm.github.io/23.2/reference/node/#pyslurm.Nodes)

--- a/docs/reference/db/jobfilter.md
+++ b/docs/reference/db/jobfilter.md
@@ -1,0 +1,6 @@
+---
+title: JobFilter
+---
+
+::: pyslurm.db.JobFilter
+    handler: python

--- a/docs/reference/db/jobsearchfilter.md
+++ b/docs/reference/db/jobsearchfilter.md
@@ -1,6 +1,0 @@
----
-title: JobSearchFilter
----
-
-::: pyslurm.db.JobSearchFilter
-    handler: python

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -37,7 +37,7 @@ The `pyslurm` package is a wrapper around the Slurm C-API
     * [pyslurm.db.Job][]
     * [pyslurm.db.JobStep][]
     * [pyslurm.db.Jobs][]
-    * [pyslurm.db.JobSearchFilter][]
+    * [pyslurm.db.JobFilter][]
 * Node API
     * [pyslurm.Node][]
     * [pyslurm.Nodes][]

--- a/pyslurm/__init__.py
+++ b/pyslurm/__init__.py
@@ -9,11 +9,15 @@ import sys
 
 sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
 
+# Initialize slurm api
+from pyslurm.api import slurm_init, slurm_fini
+slurm_init()
+
 from .pyslurm import *
 from .__version__ import __version__
 
-from pyslurm import utils
 from pyslurm import db
+from pyslurm import utils
 from pyslurm import constants
 
 from pyslurm.core.job import (
@@ -31,10 +35,6 @@ from pyslurm.core.error import (
     RPCError,
 )
 from pyslurm.core import slurmctld
-
-# Initialize slurm api
-from pyslurm.api import slurm_init, slurm_fini
-slurm_init()
 
 
 def version():

--- a/pyslurm/core/job/job.pxd
+++ b/pyslurm/core/job/job.pxd
@@ -67,7 +67,7 @@ from pyslurm.slurm cimport (
 )
 
 
-cdef class Jobs(dict):
+cdef class Jobs(list):
     """A collection of [pyslurm.Job][] objects.
 
     Args:

--- a/pyslurm/core/job/job.pyx
+++ b/pyslurm/core/job/job.pyx
@@ -234,7 +234,9 @@ cdef class Job:
         self._dealloc_impl()
 
     def __eq__(self, other):
-        return isinstance(other, Job) and self.id == other.id
+        if isinstance(other, Job):
+            return self.id == other.id and self.cluster == other.cluster
+        return NotImplemented
 
     @staticmethod
     def load(job_id):

--- a/pyslurm/core/job/step.pxd
+++ b/pyslurm/core/job/step.pxd
@@ -49,7 +49,7 @@ from pyslurm.utils.ctime cimport time_t
 from pyslurm.core.job.task_dist cimport TaskDistribution
 
 
-cdef class JobSteps(dict):
+cdef class JobSteps(list):
     """A collection of [pyslurm.JobStep][] objects for a given Job.
 
     Args:
@@ -64,11 +64,12 @@ cdef class JobSteps(dict):
     cdef:
         job_step_info_response_msg_t *info
         job_step_info_t tmp_info
+        _job_id
 
     @staticmethod
-    cdef JobSteps _load(Job job)
+    cdef JobSteps _load_single(Job job)
 
-    cdef dict _get_info(self, uint32_t job_id, int flags)
+    cdef _load_data(self, uint32_t job_id, int flags)
         
 
 cdef class JobStep:

--- a/pyslurm/core/job/step.pyx
+++ b/pyslurm/core/job/step.pyx
@@ -33,6 +33,8 @@ from pyslurm.utils.helpers import (
     uid_to_name,
     collection_to_dict,
     group_collection_by_cluster,
+    humanize_step_id,
+    dehumanize_step_id,
 )
 from pyslurm.core.job.util import cpu_freq_int_to_str
 from pyslurm.utils.ctime import (
@@ -74,7 +76,7 @@ cdef class JobSteps(list):
                                  recursive=recursive, group_id=JobStep.job_id)
         col = col.get(LOCAL_CLUSTER, {})
         if self._job_id:
-            return col.get(self._job_id)
+            return col.get(self._job_id, {})
 
         return col
 
@@ -442,29 +444,3 @@ cdef class JobStep:
     @property
     def slurm_protocol_version(self):
         return u32_parse(self.ptr.start_protocol_ver)
-
-
-def humanize_step_id(sid):
-    if sid == slurm.SLURM_BATCH_SCRIPT:
-        return "batch"
-    elif sid == slurm.SLURM_EXTERN_CONT:
-        return "extern"
-    elif sid == slurm.SLURM_INTERACTIVE_STEP:
-        return "interactive"
-    elif sid == slurm.SLURM_PENDING_STEP:
-        return "pending"
-    else:
-        return sid
-
-
-def dehumanize_step_id(sid):
-    if sid == "batch":
-        return slurm.SLURM_BATCH_SCRIPT
-    elif sid == "extern":
-        return slurm.SLURM_EXTERN_CONT
-    elif sid == "interactive":
-        return slurm.SLURM_INTERACTIVE_STEP
-    elif sid == "pending":
-        return slurm.SLURM_PENDING_STEP
-    else:
-        return int(sid)

--- a/pyslurm/core/job/step.pyx
+++ b/pyslurm/core/job/step.pyx
@@ -26,10 +26,13 @@ from typing import Union
 from pyslurm.utils import cstr, ctime
 from pyslurm.utils.uint import *
 from pyslurm.core.error import RPCError, verify_rpc
+from pyslurm.db.cluster import LOCAL_CLUSTER
 from pyslurm.utils.helpers import (
     signal_to_num,
     instance_to_dict, 
     uid_to_name,
+    collection_to_dict,
+    group_collection_by_cluster,
 )
 from pyslurm.core.job.util import cpu_freq_int_to_str
 from pyslurm.utils.ctime import (
@@ -41,7 +44,7 @@ from pyslurm.utils.ctime import (
 )
 
 
-cdef class JobSteps(dict):
+cdef class JobSteps(list):
 
     def __dealloc__(self):
         slurm_free_job_step_info_response_msg(self.info)
@@ -49,44 +52,74 @@ cdef class JobSteps(dict):
     def __cinit__(self):
         self.info = NULL
 
-    def __init__(self):
-        pass
+    def __init__(self, steps=None):
+        if isinstance(steps, list):
+            self.extend(steps)
+        elif steps is not None:
+            raise TypeError("Invalid Type: {type(steps)}")
 
-    @staticmethod
-    def load(job):
-        """Load the Steps for a specific Job
+    def as_dict(self, recursive=False):
+        """Convert the collection data to a dict.
 
         Args:
-            job (Union[Job, int]):
-                The Job for which the Steps should be loaded
+            recursive (bool, optional):
+                By default, the objects will not be converted to a dict. If
+                this is set to `True`, then additionally all objects are
+                converted to dicts.
+
+        Returns:
+            (dict): Collection as a dict.
+        """
+        col = collection_to_dict(self, identifier=JobStep.id,
+                                 recursive=recursive, group_id=JobStep.job_id)
+        col = col.get(LOCAL_CLUSTER, {})
+        if self._job_id:
+            return col.get(self._job_id)
+
+        return col
+
+    def group_by_cluster(self):
+        return group_collection_by_cluster(self)
+
+    @staticmethod
+    def load(job_id=0):
+        """Load the Job Steps from the system.
+
+        Args:
+            job_id (Union[Job, int]):
+                The Job for which the Steps should be loaded.
 
         Returns:
             (pyslurm.JobSteps): JobSteps of the Job
         """
-        cdef Job _job
-        _job = Job.load(job.id) if isinstance(job, Job) else Job.load(job)
-        return JobSteps._load(_job)
+        cdef:
+            Job job
+            JobSteps steps
+
+        if job_id:
+            job = Job.load(job_id.id if isinstance(job_id, Job) else job_id)
+            steps = JobSteps._load_single(job)
+            steps._job_id = job.id
+            return steps
+        else:
+            steps = JobSteps()
+            return steps._load_data(0, slurm.SHOW_ALL)
 
     @staticmethod
-    cdef JobSteps _load(Job job):
-        cdef JobSteps steps = JobSteps.__new__(JobSteps)
+    cdef JobSteps _load_single(Job job):
+        cdef JobSteps steps = JobSteps()
 
-        step_info = steps._get_info(job.id, slurm.SHOW_ALL)
-        if not step_info and not slurm.IS_JOB_PENDING(job.ptr):
+        steps._load_data(job.id, slurm.SHOW_ALL)
+        if not steps and not slurm.IS_JOB_PENDING(job.ptr):
             msg = f"Failed to load step info for Job {job.id}."
             raise RPCError(msg=msg)
 
-        # No super().__init__() needed? Cython probably already initialized
-        # the dict automatically.
-        steps.update(step_info[job.id])
         return steps
          
-    cdef dict _get_info(self, uint32_t job_id, int flags):
+    cdef _load_data(self, uint32_t job_id, int flags):
         cdef:
             JobStep step
-            JobSteps steps
             uint32_t cnt = 0
-            dict out = {}
 
         rc = slurm_get_job_steps(<time_t>0, job_id, slurm.NO_VAL, &self.info,
                                  flags)
@@ -102,12 +135,7 @@ cdef class JobSteps(dict):
             # Prevent double free if xmalloc fails mid-loop and a MemoryError
             # is raised by replacing it with a zeroed-out job_step_info_t.
             self.info.job_steps[cnt] = self.tmp_info
-
-            if not step.job_id in out:
-                steps = JobSteps.__new__(JobSteps)
-                out[step.job_id] = steps
-
-            out[step.job_id].update({step.id: step})
+            self.append(step)
 
         # At this point we memcpy'd all the memory for the Steps. Setting this
         # to 0 will prevent the slurm step free function to deallocate the
@@ -117,18 +145,7 @@ cdef class JobSteps(dict):
         # instance.
         self.info.job_step_count = 0
 
-        return out
-
-    @staticmethod
-    def load_all():
-        """Loads all the steps in the system.
-
-        Returns:
-            (dict): A dict where every JobID (key) is mapped with an instance
-                of its JobSteps (value).
-        """
-        cdef JobSteps steps = JobSteps.__new__(JobSteps)
-        return steps._get_info(slurm.NO_VAL, slurm.SHOW_ALL)
+        return self
 
 
 cdef class JobStep:

--- a/pyslurm/core/node.pxd
+++ b/pyslurm/core/node.pxd
@@ -57,7 +57,7 @@ from pyslurm.utils.ctime cimport time_t
 from pyslurm.utils.uint cimport *
 
 
-cdef class Nodes(dict):
+cdef class Nodes(list):
     """A collection of [pyslurm.Node][] objects.
 
     Args:

--- a/pyslurm/core/node.pxd
+++ b/pyslurm/core/node.pxd
@@ -233,6 +233,8 @@ cdef class Node:
         dict passwd
         dict groups
 
+    cdef readonly cluster
+
     @staticmethod
     cdef _swap_data(Node dst, Node src)
 

--- a/pyslurm/core/node.pyx
+++ b/pyslurm/core/node.pyx
@@ -71,7 +71,19 @@ cdef class Nodes(list):
             raise TypeError("Invalid Type: {type(nodes)}")
 
     def as_dict(self, recursive=False):
-        col = collection_to_dict(self, False, Node.name, recursive)
+        """Convert the collection data to a dict.
+
+        Args:
+            recursive (bool, optional):
+                By default, the objects will not be converted to a dict. If
+                this is set to `True`, then additionally all objects are
+                converted to dicts.
+
+        Returns:
+            (dict): Collection as a dict.
+        """
+        col = collection_to_dict(self, identifier=Node.name,
+                                 recursive=recursive)
         return col.get(LOCAL_CLUSTER, {})
 
     def group_by_cluster(self):

--- a/pyslurm/core/partition.pxd
+++ b/pyslurm/core/partition.pxd
@@ -58,7 +58,7 @@ from pyslurm.utils.uint cimport *
 from pyslurm.core cimport slurmctld
 
 
-cdef class Partitions(dict):
+cdef class Partitions(list):
     """A collection of [pyslurm.Partition][] objects.
 
     Args:
@@ -215,6 +215,8 @@ cdef class Partition:
         partition_info_t *ptr
         int power_save_enabled
         slurmctld.Config slurm_conf
+
+    cdef readonly cluster
 
     @staticmethod
     cdef Partition from_ptr(partition_info_t *in_ptr)

--- a/pyslurm/core/partition.pyx
+++ b/pyslurm/core/partition.pyx
@@ -73,7 +73,19 @@ cdef class Partitions(list):
             raise TypeError("Invalid Type: {type(partitions)}")
 
     def as_dict(self, recursive=False):
-        col = collection_to_dict(self, False, Partition.name, recursive)
+        """Convert the collection data to a dict.
+
+        Args:
+            recursive (bool, optional):
+                By default, the objects will not be converted to a dict. If
+                this is set to `True`, then additionally all objects are
+                converted to dicts.
+
+        Returns:
+            (dict): Collection as a dict.
+        """
+        col = collection_to_dict(self, identifier=Partition.name,
+                                 recursive=recursive)
         return col.get(LOCAL_CLUSTER, {})
 
     def group_by_cluster(self):

--- a/pyslurm/core/partition.pyx
+++ b/pyslurm/core/partition.pyx
@@ -57,17 +57,19 @@ cdef class Partitions(list):
         self.info = NULL
 
     def __init__(self, partitions=None):
-        if isinstance(partitions, dict):
-            self.update(partitions)
-        elif isinstance(partitions, str):
-            partlist = partitions.split(",")
-            self.update({part: Partition(part) for part in partlist})
-        elif partitions is not None:
+        if isinstance(partitions, list):
             for part in partitions:
                 if isinstance(part, str):
-                    self[part] = Partition(part)
+                    self.extend(Partition(part))
                 else:
-                    self[part.name] = part
+                    self.extend(part)
+        elif isinstance(partitions, str):
+            partlist = partitions.split(",")
+            self.extend([Partition(part) for part in partlist])
+        elif isinstance(partitions, dict):
+            self.extend([part for part in partitions.values()])
+        elif partitions is not None:
+            raise TypeError("Invalid Type: {type(partitions)}")
 
     def as_dict(self):
         return collection_to_dict(self, False, False, Partition.name)

--- a/pyslurm/db/__init__.py
+++ b/pyslurm/db/__init__.py
@@ -25,6 +25,7 @@ from .stats import JobStatistics
 from .job import (
     Job,
     Jobs,
+    JobFilter,
     JobSearchFilter,
 )
 from .tres import (
@@ -34,7 +35,7 @@ from .tres import (
 from .qos import (
     QualitiesOfService,
     QualityOfService,
-    QualityOfServiceSearchFilter,
+    QualityOfServiceFilter,
 )
 from .assoc import (
     Associations,

--- a/pyslurm/db/__init__.py
+++ b/pyslurm/db/__init__.py
@@ -36,3 +36,7 @@ from .qos import (
     QualityOfService,
     QualityOfServiceSearchFilter,
 )
+from .assoc import (
+    Associations,
+    Association,
+)

--- a/pyslurm/db/__init__.py
+++ b/pyslurm/db/__init__.py
@@ -39,4 +39,5 @@ from .qos import (
 from .assoc import (
     Associations,
     Association,
+    AssociationFilter,
 )

--- a/pyslurm/db/assoc.pxd
+++ b/pyslurm/db/assoc.pxd
@@ -1,0 +1,62 @@
+#########################################################################
+# assoc.pxd - pyslurm slurmdbd association api
+#########################################################################
+# Copyright (C) 2023 Toni Harzendorf <toni.harzendorf@gmail.com>
+#
+# This file is part of PySlurm
+#
+# PySlurm is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# PySlurm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with PySlurm; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# cython: c_string_type=unicode, c_string_encoding=default
+# cython: language_level=3
+
+from pyslurm cimport slurm
+from pyslurm.slurm cimport (
+    slurmdb_assoc_rec_t,
+    slurmdb_assoc_cond_t,
+    slurmdb_associations_get,
+    slurmdb_destroy_assoc_rec,
+    slurmdb_destroy_assoc_cond,
+    try_xmalloc,
+)
+from pyslurm.db.util cimport (
+    SlurmList,
+    SlurmListItem,
+    make_char_list,
+    slurm_list_to_pylist,
+    qos_list_to_pylist,
+)
+from pyslurm.db.connection cimport Connection
+from pyslurm.utils cimport cstr
+from pyslurm.utils.uint cimport *
+from pyslurm.db.qos cimport QualitiesOfService
+
+
+cdef class Associations(dict):
+    cdef SlurmList info
+
+
+cdef class AssociationSearchFilter:
+    cdef slurmdb_assoc_cond_t *ptr
+
+
+cdef class Association:
+    cdef:
+        slurmdb_assoc_rec_t *ptr
+        QualitiesOfService qos_data
+
+    @staticmethod
+    cdef Association from_ptr(slurmdb_assoc_rec_t *in_ptr)
+

--- a/pyslurm/db/assoc.pxd
+++ b/pyslurm/db/assoc.pxd
@@ -41,20 +41,21 @@ from pyslurm.db.util cimport (
     qos_list_to_pylist,
 )
 from pyslurm.db.tres cimport (
-    find_tres_limit,
-    merge_tres_str,
-    tres_ids_to_names,
+    _set_tres_limits,
     TrackableResources,
     TrackableResourceLimits,
 )
 from pyslurm.db.connection cimport Connection
 from pyslurm.utils cimport cstr
 from pyslurm.utils.uint cimport *
-from pyslurm.db.qos cimport QualitiesOfService
+from pyslurm.db.qos cimport QualitiesOfService, _set_qos_list
+
+cdef _parse_assoc_ptr(Association ass)
+cdef _create_assoc_ptr(Association ass, conn=*)
 
 
 cdef class Associations(dict):
-    cdef SlurmList info
+    pass
 
 
 cdef class AssociationFilter:
@@ -79,6 +80,7 @@ cdef class Association:
         max_tres_run_mins_per_user
         max_tres_per_job
         max_tres_per_node
+        qos
 
     @staticmethod
     cdef Association from_ptr(slurmdb_assoc_rec_t *in_ptr)

--- a/pyslurm/db/assoc.pxd
+++ b/pyslurm/db/assoc.pxd
@@ -30,6 +30,7 @@ from pyslurm.slurm cimport (
     slurmdb_destroy_assoc_rec,
     slurmdb_destroy_assoc_cond,
     slurmdb_init_assoc_rec,
+    slurmdb_associations_modify,
     try_xmalloc,
 )
 from pyslurm.db.util cimport (
@@ -42,6 +43,8 @@ from pyslurm.db.util cimport (
 from pyslurm.db.tres cimport (
     find_tres_limit,
     merge_tres_str,
+    tres_ids_to_names,
+    TrackableResources,
 )
 from pyslurm.db.connection cimport Connection
 from pyslurm.utils cimport cstr
@@ -53,14 +56,19 @@ cdef class Associations(dict):
     cdef SlurmList info
 
 
-cdef class AssociationSearchFilter:
+cdef class AssociationFilter:
     cdef slurmdb_assoc_cond_t *ptr
+
+    cdef public:
+        users
+        ids
 
 
 cdef class Association:
     cdef:
         slurmdb_assoc_rec_t *ptr
         QualitiesOfService qos_data
+        TrackableResources tres_data
 
     @staticmethod
     cdef Association from_ptr(slurmdb_assoc_rec_t *in_ptr)

--- a/pyslurm/db/assoc.pxd
+++ b/pyslurm/db/assoc.pxd
@@ -69,8 +69,8 @@ cdef class AssociationFilter:
 cdef class Association:
     cdef:
         slurmdb_assoc_rec_t *ptr
-        QualitiesOfService qos_data
-        TrackableResources tres_data
+        dict qos_data
+        dict tres_data
 
     cdef public:
         group_tres

--- a/pyslurm/db/assoc.pxd
+++ b/pyslurm/db/assoc.pxd
@@ -54,7 +54,7 @@ cdef _parse_assoc_ptr(Association ass)
 cdef _create_assoc_ptr(Association ass, conn=*)
 
 
-cdef class Associations(dict):
+cdef class Associations(list):
     pass
 
 

--- a/pyslurm/db/assoc.pxd
+++ b/pyslurm/db/assoc.pxd
@@ -29,6 +29,7 @@ from pyslurm.slurm cimport (
     slurmdb_associations_get,
     slurmdb_destroy_assoc_rec,
     slurmdb_destroy_assoc_cond,
+    slurmdb_init_assoc_rec,
     try_xmalloc,
 )
 from pyslurm.db.util cimport (
@@ -37,6 +38,10 @@ from pyslurm.db.util cimport (
     make_char_list,
     slurm_list_to_pylist,
     qos_list_to_pylist,
+)
+from pyslurm.db.tres cimport (
+    find_tres_limit,
+    merge_tres_str,
 )
 from pyslurm.db.connection cimport Connection
 from pyslurm.utils cimport cstr

--- a/pyslurm/db/assoc.pxd
+++ b/pyslurm/db/assoc.pxd
@@ -45,6 +45,7 @@ from pyslurm.db.tres cimport (
     merge_tres_str,
     tres_ids_to_names,
     TrackableResources,
+    TrackableResourceLimits,
 )
 from pyslurm.db.connection cimport Connection
 from pyslurm.utils cimport cstr
@@ -69,6 +70,15 @@ cdef class Association:
         slurmdb_assoc_rec_t *ptr
         QualitiesOfService qos_data
         TrackableResources tres_data
+
+    cdef public:
+        group_tres
+        group_tres_mins
+        group_tres_run_mins
+        max_tres_mins_per_job
+        max_tres_run_mins_per_user
+        max_tres_per_job
+        max_tres_per_node
 
     @staticmethod
     cdef Association from_ptr(slurmdb_assoc_rec_t *in_ptr)

--- a/pyslurm/db/assoc.pyx
+++ b/pyslurm/db/assoc.pyx
@@ -1,0 +1,360 @@
+#########################################################################
+# assoc.pyx - pyslurm slurmdbd association api
+#########################################################################
+# Copyright (C) 2023 Toni Harzendorf <toni.harzendorf@gmail.com>
+#
+# This file is part of PySlurm
+#
+# PySlurm is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# PySlurm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with PySlurm; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# cython: c_string_type=unicode, c_string_encoding=default
+# cython: language_level=3
+
+from pyslurm.core.error import RPCError
+from pyslurm.utils.helpers import instance_to_dict
+from pyslurm.utils.uint import *
+
+
+cdef class Associations(dict):
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def load(AssociationSearchFilter search_filter=None,
+             Connection db_connection=None):
+        cdef:
+            Associations assoc_dict = Associations()
+            Association assoc
+            AssociationSearchFilter cond = search_filter
+            SlurmListItem assoc_ptr
+            Connection conn = db_connection
+            QualitiesOfService qos_data
+
+        if not search_filter:
+            cond = AssociationSearchFilter()
+        cond._create()
+
+        if not conn:
+            conn = Connection.open()
+
+        assoc_dict.info = SlurmList.wrap(
+                slurmdb_associations_get(conn.ptr, cond.ptr))
+        
+        if assoc_dict.info.is_null:
+            raise RPCError(msg="Failed to get Association data from slurmdbd")
+
+        qos_data = QualitiesOfService.load(name_is_key=False,
+                                           db_connection=conn)
+
+        for assoc_ptr in SlurmList.iter_and_pop(assoc_dict.info):
+            assoc = Association.from_ptr(<slurmdb_assoc_rec_t*>assoc_ptr.data)
+            assoc.qos_data = qos_data
+            assoc_dict[assoc.id] = assoc
+
+        return assoc_dict
+
+
+cdef class AssociationSearchFilter:
+
+    def __cinit__(self):
+        self.ptr = NULL
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __dealloc__(self):
+        self._dealloc()
+
+    def _dealloc(self):
+        slurmdb_destroy_assoc_cond(self.ptr)
+        self.ptr = NULL
+
+    def _alloc(self):
+        self._dealloc()
+        self.ptr = <slurmdb_assoc_cond_t*>try_xmalloc(sizeof(slurmdb_assoc_cond_t))
+        if not self.ptr:
+            raise MemoryError("xmalloc failed for slurmdb_assoc_cond_t")
+
+    def _create(self):
+        self._alloc()
+        cdef slurmdb_assoc_cond_t *ptr = self.ptr
+
+
+cdef class Association:
+
+    def __cinit__(self):
+        self.ptr = NULL
+
+    def __init__(self):
+        self._alloc_impl()
+
+    def __dealloc__(self):
+        self._dealloc_impl()
+
+    def _dealloc_impl(self):
+        slurmdb_destroy_assoc_rec(self.ptr)
+        self.ptr = NULL
+
+    def _alloc_impl(self):
+        if not self.ptr:
+            self.ptr = <slurmdb_assoc_rec_t*>try_xmalloc(
+                    sizeof(slurmdb_assoc_rec_t))
+            if not self.ptr:
+                raise MemoryError("xmalloc failed for slurmdb_assoc_rec_t")
+
+    @staticmethod
+    cdef Association from_ptr(slurmdb_assoc_rec_t *in_ptr):
+        cdef Association wrap = Association.__new__(Association)
+        wrap.ptr = in_ptr
+        return wrap
+
+    def as_dict(self):
+        """Database Association information formatted as a dictionary.
+
+        Returns:
+            (dict): Database Association information as dict
+        """
+        return instance_to_dict(self)
+
+    @staticmethod
+    def load(name):
+        pass
+
+    @property
+    def account(self):
+        return cstr.to_unicode(self.ptr.acct)
+
+    @account.setter
+    def account(self, val):
+        cstr.fmalloc(&self.ptr.acct, val)
+
+    @property
+    def cluster(self):
+        return cstr.to_unicode(self.ptr.cluster)
+
+    @cluster.setter
+    def cluster(self, val):
+        cstr.fmalloc(&self.ptr.cluster, val)
+
+    @property
+    def comment(self):
+        return cstr.to_unicode(self.ptr.comment)
+
+    @comment.setter
+    def comment(self, val):
+        cstr.fmalloc(&self.ptr.comment, val)
+
+    # uint32_t def_qos_id
+
+    # uint16_t flags (ASSOC_FLAG_*)
+
+    @property
+    def group_jobs(self):
+        return u32_parse(self.ptr.grp_jobs, zero_is_noval=False)
+
+    @group_jobs.setter
+    def group_jobs(self, val):
+        self.ptr.grp_jobs = u32(val, zero_is_noval=False)
+
+    @property
+    def group_jobs_accrue(self):
+        return u32_parse(self.ptr.grp_jobs_accrue, zero_is_noval=False)
+
+    @group_jobs_accrue.setter
+    def group_jobs_accrue(self, val):
+        self.ptr.grp_jobs_accrue = u32(val, zero_is_noval=False)
+
+    @property
+    def group_submit_jobs(self):
+        return u32_parse(self.ptr.grp_submit_jobs, zero_is_noval=False)
+
+    @group_submit_jobs.setter
+    def group_submit_jobs(self, val):
+        self.ptr.grp_submit_jobs = u32(val, zero_is_noval=False)
+
+    @property
+    def group_tres(self):
+        return cstr.to_dict(self.ptr.grp_tres)
+
+    @group_tres.setter
+    def group_tres(self, val):
+        cstr.from_dict(&self.ptr.grp_tres, val)
+
+    @property
+    def group_tres_mins(self):
+        return cstr.to_dict(self.ptr.grp_tres_mins)
+
+    @group_tres_mins.setter
+    def group_tres_mins(self, val):
+        cstr.from_dict(&self.ptr.grp_tres_mins, val)
+
+    @property
+    def group_tres_run_mins(self):
+        return cstr.to_dict(self.ptr.grp_tres_run_mins)
+
+    @group_tres_run_mins.setter
+    def group_tres_run_mins(self, val):
+        cstr.from_dict(&self.ptr.grp_tres_run_mins, val)
+
+    @property
+    def group_wall_time(self):
+        return u32_parse(self.ptr.grp_wall, zero_is_noval=False)
+
+    @group_wall_time.setter
+    def group_wall_time(self, val):
+        self.ptr.grp_wall = u32(val, zero_is_noval=False)
+
+    @property
+    def id(self):
+        return self.ptr.id
+
+    @id.setter
+    def id(self, val):
+        self.ptr.id = val
+
+    @property
+    def is_default(self):
+        return u16_parse_bool(self.ptr.is_def)
+
+    @property
+    def lft(self):
+        return self.ptr.lft
+
+    @property
+    def max_jobs(self):
+        return u32_parse(self.ptr.max_jobs, zero_is_noval=False)
+
+    @max_jobs.setter
+    def max_jobs(self, val):
+        self.ptr.max_jobs = u32(val, zero_is_noval=False)
+
+    @property
+    def max_jobs_accrue(self):
+        return u32_parse(self.ptr.max_jobs_accrue, zero_is_noval=False)
+
+    @max_jobs_accrue.setter
+    def max_jobs_accrue(self, val):
+        self.ptr.max_jobs_accrue = u32(val, zero_is_noval=False)
+
+    @property
+    def max_submit_jobs(self):
+        return u32_parse(self.ptr.max_submit_jobs, zero_is_noval=False)
+
+    @max_submit_jobs.setter
+    def max_submit_jobs(self, val):
+        self.ptr.max_submit_jobs = u32(val, zero_is_noval=False)
+
+    @property
+    def max_tres_mins_per_job(self):
+        return cstr.to_dict(self.ptr.max_tres_mins_pj)
+
+    @max_tres_mins_per_job.setter
+    def max_tres_mins_per_job(self, val):
+        cstr.from_dict(&self.ptr.max_tres_mins_pj, val)
+
+    @property
+    def max_tres_run_mins_per_user(self):
+        return cstr.to_dict(self.ptr.max_tres_run_mins)
+
+    @max_tres_run_mins_per_user.setter
+    def max_tres_run_mins_per_user(self, val):
+        cstr.from_dict(&self.ptr.max_tres_run_mins, val)
+
+    @property
+    def max_tres_per_job(self):
+        return cstr.to_dict(self.ptr.max_tres_pj)
+
+    @max_tres_per_job.setter
+    def max_tres_per_job(self, val):
+        cstr.from_dict(&self.ptr.max_tres_pj, val)
+
+    @property
+    def max_tres_per_node(self):
+        return cstr.to_dict(self.ptr.max_tres_pn)
+
+    @max_tres_per_node.setter
+    def max_tres_per_node(self, val):
+        cstr.from_dict(&self.ptr.max_tres_pn, val)
+
+    @property
+    def max_wall_time_per_job(self):
+        return u32_parse(self.ptr.max_wall_pj, zero_is_noval=False)
+
+    @max_wall_time_per_job.setter
+    def max_wall_time_per_job(self, val):
+        self.ptr.max_wall_pj = u32(val, zero_is_noval=False)
+
+    @property
+    def min_priority_threshold(self):
+        return u32_parse(self.ptr.min_prio_thresh, zero_is_noval=False)
+
+    @min_priority_threshold.setter
+    def min_priority_threshold(self, val):
+        self.ptr.min_prio_thresh = u32(val, zero_is_noval=False)
+
+    @property
+    def parent_account(self):
+        return cstr.to_unicode(self.ptr.parent_acct)
+
+    @property
+    def parent_account_id(self):
+        return u32_parse(self.ptr.parent_id, zero_is_noval=False)
+
+    @property
+    def partition(self):
+        return cstr.to_unicode(self.ptr.partition)
+
+    @partition.setter
+    def partition(self, val):
+        cstr.fmalloc(&self.ptr.partition, val)
+
+    @property
+    def priority(self):
+        return u32_parse(self.ptr.priority, zero_is_noval=False)
+
+    @priority.setter
+    def priority(self, val):
+        self.ptr.priority = u32(val)
+
+    @property
+    def qos(self):
+        return qos_list_to_pylist(self.ptr.qos_list, self.qos_data)
+
+    @qos.setter
+    def qos(self, val):
+        make_char_list(&self.ptr.qos_list, val)
+
+    @property
+    def rgt(self):
+        return self.ptr.rgt
+
+    @property
+    def shares(self):
+        return u32_parse(self.ptr.shares_raw, zero_is_noval=False)
+
+    @shares.setter
+    def shares(self, val):
+        self.ptr.shares_raw = u32(val)
+
+    @property
+    def user(self):
+        return cstr.to_unicode(self.ptr.user)
+
+    @user.setter
+    def user(self, val):
+        cstr.fmalloc(&self.ptr.user, val)
+

--- a/pyslurm/db/assoc.pyx
+++ b/pyslurm/db/assoc.pyx
@@ -40,7 +40,25 @@ cdef class Associations(list):
         pass
 
     def as_dict(self, recursive=False, group_by_cluster=False):
-        col = collection_to_dict(self, False, Association.id, recursive)
+        """Convert the collection data to a dict.
+
+        Args:
+            recursive (bool, optional):
+                By default, the objects will not be converted to a dict. If
+                this is set to `True`, then additionally all objects are
+                converted to dicts.
+            group_by_cluster (bool, optional):
+                By default, only the Jobs from your local Cluster are
+                returned. If this is set to `True`, then all the Jobs in the
+                collection will be grouped by the Cluster - with the name of
+                the cluster as the key and the value being the collection as
+                another dict.
+
+        Returns:
+            (dict): Collection as a dict.
+        """
+        col = collection_to_dict(self, identifier=Association.id,
+                                 recursive=recursive)
         if not group_by_cluster:
             return col.get(LOCAL_CLUSTER, {})
 

--- a/pyslurm/db/assoc.pyx
+++ b/pyslurm/db/assoc.pyx
@@ -31,6 +31,7 @@ from pyslurm.utils.helpers import (
 )
 from pyslurm.utils.uint import *
 from pyslurm.db.connection import _open_conn_or_error
+from pyslurm.db.cluster import LOCAL_CLUSTER
 
 
 cdef class Associations(list):
@@ -38,8 +39,12 @@ cdef class Associations(list):
     def __init__(self):
         pass
 
-    def as_dict(self, group_by_cluster=False):
-        return collection_to_dict(self, group_by_cluster, True, Association.id)
+    def as_dict(self, recursive=False, group_by_cluster=False):
+        col = collection_to_dict(self, False, Association.id, recursive)
+        if not group_by_cluster:
+            return col.get(LOCAL_CLUSTER, {})
+
+        return col
 
     def group_by_cluster(self):
         return group_collection_by_cluster(self) 
@@ -183,6 +188,7 @@ cdef class Association:
     def __init__(self, **kwargs):
         self._alloc_impl()
         self.id = 0
+        self.cluster = LOCAL_CLUSTER
         for k, v in kwargs.items():
             setattr(self, k, v)
 

--- a/pyslurm/db/assoc.pyx
+++ b/pyslurm/db/assoc.pyx
@@ -116,6 +116,8 @@ cdef class Association:
             if not self.ptr:
                 raise MemoryError("xmalloc failed for slurmdb_assoc_rec_t")
 
+            slurmdb_init_assoc_rec(self.ptr, 0)
+
     @staticmethod
     cdef Association from_ptr(slurmdb_assoc_rec_t *in_ptr):
         cdef Association wrap = Association.__new__(Association)
@@ -193,6 +195,14 @@ cdef class Association:
     @group_tres.setter
     def group_tres(self, val):
         cstr.from_dict(&self.ptr.grp_tres, val)
+
+    @property
+    def group_cpus(self):
+        return find_tres_limit(self.ptr.grp_tres, slurm.TRES_CPU)
+
+    @group_cpus.setter
+    def group_cpus(self, val):
+        merge_tres_str(&self.ptr.grp_tres, slurm.TRES_CPU, val)
 
     @property
     def group_tres_mins(self):

--- a/pyslurm/db/cluster.pxd
+++ b/pyslurm/db/cluster.pxd
@@ -1,5 +1,5 @@
 #########################################################################
-# db/__init__.py - pyslurm database api
+# cluster.pxd - pyslurm slurmdbd cluster api
 #########################################################################
 # Copyright (C) 2023 Toni Harzendorf <toni.harzendorf@gmail.com>
 #
@@ -18,28 +18,10 @@
 # You should have received a copy of the GNU General Public License along
 # with PySlurm; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# cython: c_string_type=unicode, c_string_encoding=default
+# cython: language_level=3
 
-from .connection import Connection
-from .step import JobStep, JobSteps
-from .stats import JobStatistics
-from .job import (
-    Job,
-    Jobs,
-    JobFilter,
-    JobSearchFilter,
-)
-from .tres import (
-    TrackableResource,
-    TrackableResources,
-)
-from .qos import (
-    QualitiesOfService,
-    QualityOfService,
-    QualityOfServiceFilter,
-)
-from .assoc import (
-    Associations,
-    Association,
-    AssociationFilter,
-)
-from . import cluster
+
+from pyslurm cimport slurm
+from pyslurm.utils cimport cstr

--- a/pyslurm/db/cluster.pyx
+++ b/pyslurm/db/cluster.pyx
@@ -1,5 +1,5 @@
 #########################################################################
-# db/__init__.py - pyslurm database api
+# cluster.pyx - pyslurm slurmdbd cluster api
 #########################################################################
 # Copyright (C) 2023 Toni Harzendorf <toni.harzendorf@gmail.com>
 #
@@ -18,28 +18,14 @@
 # You should have received a copy of the GNU General Public License along
 # with PySlurm; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# cython: c_string_type=unicode, c_string_encoding=default
+# cython: language_level=3
 
-from .connection import Connection
-from .step import JobStep, JobSteps
-from .stats import JobStatistics
-from .job import (
-    Job,
-    Jobs,
-    JobFilter,
-    JobSearchFilter,
-)
-from .tres import (
-    TrackableResource,
-    TrackableResources,
-)
-from .qos import (
-    QualitiesOfService,
-    QualityOfService,
-    QualityOfServiceFilter,
-)
-from .assoc import (
-    Associations,
-    Association,
-    AssociationFilter,
-)
-from . import cluster
+from pyslurm.core import slurmctld
+
+
+LOCAL_CLUSTER = cstr.to_unicode(slurm.slurm_conf.cluster_name)
+if not LOCAL_CLUSTER:
+    slurm_conf = slurmctld.Config.load()
+    LOCAL_CLUSTER = slurm_conf.cluster

--- a/pyslurm/db/connection.pyx
+++ b/pyslurm/db/connection.pyx
@@ -25,6 +25,16 @@
 from pyslurm.core.error import RPCError
 
 
+def _open_conn_or_error(conn):
+    if not conn:
+        conn = Connection.open()
+
+    if not conn.is_open:
+        raise ValueError("Database connection is not open")
+
+    return conn
+
+
 cdef class Connection:
 
     def __cinit__(self):

--- a/pyslurm/db/job.pxd
+++ b/pyslurm/db/job.pxd
@@ -55,7 +55,7 @@ from pyslurm.db.qos cimport QualitiesOfService
 from pyslurm.db.tres cimport TrackableResources, TrackableResource
 
 
-cdef class JobSearchFilter:
+cdef class JobFilter:
     """Query-Conditions for Jobs in the Slurm Database.
 
     Args:

--- a/pyslurm/db/job.pxd
+++ b/pyslurm/db/job.pxd
@@ -283,7 +283,7 @@ cdef class Job:
     """
     cdef:
         slurmdb_job_rec_t *ptr
-        QualitiesOfService qos_data
+        dict qos_data
 
     cdef public:
         JobSteps steps

--- a/pyslurm/db/job.pxd
+++ b/pyslurm/db/job.pxd
@@ -150,7 +150,7 @@ cdef class JobFilter:
         with_env
 
 
-cdef class Jobs(dict):
+cdef class Jobs(list):
     """A collection of [pyslurm.db.Job][] objects."""
     pass
 

--- a/pyslurm/db/job.pxd
+++ b/pyslurm/db/job.pxd
@@ -152,9 +152,7 @@ cdef class JobSearchFilter:
 
 cdef class Jobs(dict):
     """A collection of [pyslurm.db.Job][] objects."""
-    cdef:
-        SlurmList info
-        Connection db_conn
+    pass
 
 
 cdef class Job:

--- a/pyslurm/db/job.pyx
+++ b/pyslurm/db/job.pyx
@@ -207,7 +207,24 @@ cdef class Jobs(list):
             raise TypeError("Invalid Type: {type(jobs)}")
 
     def as_dict(self, recursive=False, group_by_cluster=False):
-        col = collection_to_dict(self, False, Job.id, recursive)
+        """Convert the collection data to a dict.
+
+        Args:
+            recursive (bool, optional):
+                By default, the objects will not be converted to a dict. If
+                this is set to `True`, then additionally all objects are
+                converted to dicts.
+            group_by_cluster (bool, optional):
+                By default, only the Jobs from your local Cluster are
+                returned. If this is set to `True`, then all the Jobs in the
+                collection will be grouped by the Cluster - with the name of
+                the cluster as the key and the value being the collection as
+                another dict.
+
+        Returns:
+            (dict): Collection as a dict.
+        """
+        col = collection_to_dict(self, identifier=Job.id, recursive=recursive)
         if not group_by_cluster:
             return col.get(LOCAL_CLUSTER, {})
 

--- a/pyslurm/db/job.pyx
+++ b/pyslurm/db/job.pyx
@@ -231,6 +231,11 @@ cdef class Jobs(list):
         return col
 
     def group_by_cluster(self):
+        """Group Jobs by cluster name
+
+        Returns:
+            (dict[str, Jobs]): Jobs grouped by cluster.
+        """
         return group_collection_by_cluster(self)
 
     @staticmethod

--- a/pyslurm/db/qos.pxd
+++ b/pyslurm/db/qos.pxd
@@ -48,7 +48,7 @@ cdef class QualitiesOfService(dict):
     pass
 
 
-cdef class QualityOfServiceSearchFilter:
+cdef class QualityOfServiceFilter:
    cdef slurmdb_qos_cond_t *ptr
 
    cdef public:

--- a/pyslurm/db/qos.pxd
+++ b/pyslurm/db/qos.pxd
@@ -30,6 +30,7 @@ from pyslurm.slurm cimport (
     slurmdb_destroy_qos_cond,
     slurmdb_qos_get,
     slurm_preempt_mode_num,
+    List,
     try_xmalloc,
 )
 from pyslurm.db.util cimport (
@@ -40,11 +41,11 @@ from pyslurm.db.util cimport (
 from pyslurm.db.connection cimport Connection
 from pyslurm.utils cimport cstr
 
+cdef _set_qos_list(List *in_list, vals, QualitiesOfService data)
+
 
 cdef class QualitiesOfService(dict):
-    cdef:
-        SlurmList info
-        Connection db_conn
+    pass
 
 
 cdef class QualityOfServiceSearchFilter:

--- a/pyslurm/db/qos.pxd
+++ b/pyslurm/db/qos.pxd
@@ -44,7 +44,7 @@ from pyslurm.utils cimport cstr
 cdef _set_qos_list(List *in_list, vals, QualitiesOfService data)
 
 
-cdef class QualitiesOfService(dict):
+cdef class QualitiesOfService(list):
     pass
 
 

--- a/pyslurm/db/qos.pyx
+++ b/pyslurm/db/qos.pyx
@@ -54,19 +54,19 @@ cdef class QualitiesOfService(dict):
         pass
 
     @staticmethod
-    def load(QualityOfServiceSearchFilter db_filter=None,
+    def load(QualityOfServiceFilter db_filter=None,
              db_connection=None, name_is_key=True):
         cdef:
             QualitiesOfService out = QualitiesOfService()
             QualityOfService qos
-            QualityOfServiceSearchFilter cond = db_filter
+            QualityOfServiceFilter cond = db_filter
             SlurmList qos_data
             SlurmListItem qos_ptr
             Connection conn
 
         # Prepare SQL Filter
         if not db_filter:
-            cond = QualityOfServiceSearchFilter()
+            cond = QualityOfServiceFilter()
         cond._create()
 
         # Setup DB Conn
@@ -89,7 +89,7 @@ cdef class QualitiesOfService(dict):
         return out
 
 
-cdef class QualityOfServiceSearchFilter:
+cdef class QualityOfServiceFilter:
 
     def __cinit__(self):
         self.ptr = NULL
@@ -195,7 +195,7 @@ cdef class QualityOfService:
             RPCError: If requesting the information from the database was not
                 sucessful.
         """
-        qfilter = QualityOfServiceSearchFilter(names=[name])
+        qfilter = QualityOfServiceFilter(names=[name])
         qos_data = QualitiesOfService.load(qfilter)
         if not qos_data or name not in qos_data:
             raise RPCError(msg=f"QualityOfService {name} does not exist")

--- a/pyslurm/db/qos.pyx
+++ b/pyslurm/db/qos.pyx
@@ -23,7 +23,7 @@
 # cython: language_level=3
 
 from pyslurm.core.error import RPCError
-from pyslurm.utils.helpers import instance_to_dict, collection_to_dict
+from pyslurm.utils.helpers import instance_to_dict, collection_to_dict_global
 from pyslurm.db.connection import _open_conn_or_error
 
 
@@ -33,14 +33,31 @@ cdef class QualitiesOfService(list):
         pass
 
     def as_dict(self, recursive=False, name_is_key=True):
+        """Convert the collection data to a dict.
+
+        Args:
+            recursive (bool, optional):
+                By default, the objects will not be converted to a dict. If
+                this is set to `True`, then additionally all objects are
+                converted to dicts.
+            name_is_key (bool, optional):
+                By default, the keys in this dict are the names of each QoS.
+                If this is set to `False`, then the unique ID of the QoS will
+                be used as dict keys.
+
+        Returns:
+            (dict): Collection as a dict.
+        """
         identifier = QualityOfService.name
         if not name_is_key:
             identifier = QualityOfService.id
 
-        return collection_to_dict(self, True, identifier, recursive)
+        return collection_to_dict_global(self, identifier=identifier,
+                                         recursive=recursive)
 
     @staticmethod
-    def load(QualityOfServiceFilter db_filter=None, db_connection=None):
+    def load(QualityOfServiceFilter db_filter=None,
+             Connection db_connection=None):
         cdef:
             QualitiesOfService out = QualitiesOfService()
             QualityOfService qos

--- a/pyslurm/db/step.pyx
+++ b/pyslurm/db/step.pyx
@@ -32,9 +32,9 @@ from pyslurm.utils.helpers import (
     uid_to_name,
     instance_to_dict,
     _get_exit_code,
+    humanize_step_id,
 )
 from pyslurm.core.job.util import cpu_freq_int_to_str
-from pyslurm.core.job.step import humanize_step_id
 
 
 cdef class JobStep:

--- a/pyslurm/db/tres.pxd
+++ b/pyslurm/db/tres.pxd
@@ -45,6 +45,24 @@ cdef merge_tres_str(char **tres_str, typ, val)
 cdef tres_ids_to_names(char *tres_str, TrackableResources tres_data)
 
 
+cdef class TrackableResourceLimits:
+
+    cdef public:
+        cpu
+        mem
+        energy
+        node
+        billing
+        fs
+        vmem
+        pages
+        gres
+        license
+
+    @staticmethod
+    cdef from_ids(char *tres_id_str, TrackableResources tres_data)
+
+
 cdef class TrackableResourceFilter:
     cdef slurmdb_tres_cond_t *ptr
 

--- a/pyslurm/db/tres.pxd
+++ b/pyslurm/db/tres.pxd
@@ -42,7 +42,9 @@ from pyslurm.db.connection cimport Connection
 cdef find_tres_count(char *tres_str, typ, on_noval=*, on_inf=*)
 cdef find_tres_limit(char *tres_str, typ)
 cdef merge_tres_str(char **tres_str, typ, val)
-cdef tres_ids_to_names(char *tres_str, TrackableResources tres_data)
+cdef _tres_ids_to_names(char *tres_str, TrackableResources tres_data)
+cdef _set_tres_limits(char **dest, TrackableResourceLimits src,
+                          TrackableResources tres_data)
 
 
 cdef class TrackableResourceLimits:

--- a/pyslurm/db/tres.pxd
+++ b/pyslurm/db/tres.pxd
@@ -30,12 +30,18 @@ from pyslurm.slurm cimport (
     try_xmalloc,
 )
 
+cdef find_tres_limit(char *tres_str, typ)
+cdef merge_tres_str(char **tres_str, typ, val)
+
 
 cdef class TrackableResources(dict):
     cdef public raw_str
 
     @staticmethod
     cdef TrackableResources from_str(char *tres_str)
+
+    @staticmethod
+    cdef find_count_in_str(char *tres_str, typ, on_noval=*, on_inf=*)
 
 
 cdef class TrackableResource:

--- a/pyslurm/db/tres.pxd
+++ b/pyslurm/db/tres.pxd
@@ -42,7 +42,7 @@ from pyslurm.db.connection cimport Connection
 cdef find_tres_count(char *tres_str, typ, on_noval=*, on_inf=*)
 cdef find_tres_limit(char *tres_str, typ)
 cdef merge_tres_str(char **tres_str, typ, val)
-cdef _tres_ids_to_names(char *tres_str, TrackableResources tres_data)
+cdef _tres_ids_to_names(char *tres_str, dict tres_data)
 cdef _set_tres_limits(char **dest, TrackableResourceLimits src,
                           TrackableResources tres_data)
 
@@ -62,7 +62,7 @@ cdef class TrackableResourceLimits:
         license
 
     @staticmethod
-    cdef from_ids(char *tres_id_str, TrackableResources tres_data)
+    cdef from_ids(char *tres_id_str, dict tres_data)
 
 
 cdef class TrackableResourceFilter:

--- a/pyslurm/db/tres.pxd
+++ b/pyslurm/db/tres.pxd
@@ -69,7 +69,7 @@ cdef class TrackableResourceFilter:
     cdef slurmdb_tres_cond_t *ptr
 
 
-cdef class TrackableResources(dict):
+cdef class TrackableResources(list):
     cdef public raw_str
 
     @staticmethod

--- a/pyslurm/db/tres.pxd
+++ b/pyslurm/db/tres.pxd
@@ -25,13 +25,28 @@ from pyslurm.utils cimport cstr
 from libc.stdint cimport uint64_t
 from pyslurm.slurm cimport (
     slurmdb_tres_rec_t,
+    slurmdb_tres_cond_t,
+    slurmdb_destroy_tres_cond,
+    slurmdb_init_tres_cond,
     slurmdb_destroy_tres_rec,
     slurmdb_find_tres_count_in_string,
+    slurmdb_tres_get,
     try_xmalloc,
 )
+from pyslurm.db.util cimport (
+    SlurmList,
+    SlurmListItem,
+)
+from pyslurm.db.connection cimport Connection
 
+cdef find_tres_count(char *tres_str, typ, on_noval=*, on_inf=*)
 cdef find_tres_limit(char *tres_str, typ)
 cdef merge_tres_str(char **tres_str, typ, val)
+cdef tres_ids_to_names(char *tres_str, TrackableResources tres_data)
+
+
+cdef class TrackableResourceFilter:
+    cdef slurmdb_tres_cond_t *ptr
 
 
 cdef class TrackableResources(dict):

--- a/pyslurm/db/tres.pyx
+++ b/pyslurm/db/tres.pyx
@@ -25,7 +25,7 @@
 from pyslurm.utils.uint import *
 from pyslurm.constants import UNLIMITED
 from pyslurm.core.error import RPCError
-from pyslurm.utils.helpers import instance_to_dict
+from pyslurm.utils.helpers import instance_to_dict, collection_to_dict
 from pyslurm.utils import cstr
 from pyslurm.db.connection import _open_conn_or_error
 import json
@@ -56,7 +56,7 @@ cdef class TrackableResourceLimits:
                 setattr(self, k, v)
 
     @staticmethod
-    cdef from_ids(char *tres_id_str, TrackableResources tres_data):
+    cdef from_ids(char *tres_id_str, dict tres_data):
         tres_list = _tres_ids_to_names(tres_id_str, tres_data)
         if not tres_list:
             return None
@@ -144,7 +144,7 @@ cdef class TrackableResources(list):
         if not name_is_key:
             identifier = TrackableResource.id
 
-        return collection_to_dict(self, False, True, identifier)
+        return collection_to_dict(self, True, identifier)
 
     @staticmethod
     def load(Connection db_connection=None, name_is_key=True):
@@ -288,7 +288,7 @@ cdef merge_tres_str(char **tres_str, typ, val):
     cstr.from_dict(tres_str, current)
 
 
-cdef _tres_ids_to_names(char *tres_str, TrackableResources tres_data):
+cdef _tres_ids_to_names(char *tres_str, dict tres_data):
     if not tres_str:
         return None
 

--- a/pyslurm/db/util.pxd
+++ b/pyslurm/db/util.pxd
@@ -39,6 +39,7 @@ from pyslurm.slurm cimport (
 
 cdef slurm_list_to_pylist(List in_list)
 cdef make_char_list(List *in_list, vals)
+cdef qos_list_to_pylist(List in_list, qos_data)
 
 
 cdef class SlurmListItem:

--- a/pyslurm/db/util.pyx
+++ b/pyslurm/db/util.pyx
@@ -43,6 +43,13 @@ cdef slurm_list_to_pylist(List in_list):
     return SlurmList.wrap(in_list, owned=False).to_pylist()
 
 
+cdef qos_list_to_pylist(List in_list, qos_data):
+    cdef list qos_nums = SlurmList.wrap(in_list, owned=False).to_pylist()
+
+    return [qos.name for qos_id, qos in qos_data.items()
+            if qos_id in qos_nums]
+
+
 cdef class SlurmListItem:
     
     def __cinit__(self):

--- a/pyslurm/db/util.pyx
+++ b/pyslurm/db/util.pyx
@@ -44,8 +44,10 @@ cdef slurm_list_to_pylist(List in_list):
 
 
 cdef qos_list_to_pylist(List in_list, qos_data):
-    cdef list qos_nums = SlurmList.wrap(in_list, owned=False).to_pylist()
+    if not in_list:
+        return []
 
+    cdef list qos_nums = SlurmList.wrap(in_list, owned=False).to_pylist()
     return [qos.name for qos_id, qos in qos_data.items()
             if qos_id in qos_nums]
 

--- a/pyslurm/slurm/extra.pxi
+++ b/pyslurm/slurm/extra.pxi
@@ -165,6 +165,9 @@ ctypedef enum tres_types_t:
 # Global Environment
 cdef extern char **environ
 
+# Local slurm config
+cdef extern slurm_conf_t slurm_conf
+
 #
 # Slurm Memory routines
 # We simply use the macros from xmalloc.h - more convenient

--- a/pyslurm/slurm/extra.pxi
+++ b/pyslurm/slurm/extra.pxi
@@ -272,6 +272,7 @@ cdef extern char *slurm_hostlist_deranged_string_malloc(hostlist_t hl)
 cdef extern void slurmdb_job_cond_def_start_end(slurmdb_job_cond_t *job_cond)
 cdef extern uint64_t slurmdb_find_tres_count_in_string(char *tres_str_in, int id)
 cdef extern slurmdb_job_rec_t *slurmdb_create_job_rec()
+cdef extern void slurmdb_init_assoc_rec(slurmdb_assoc_rec_t *assoc, bool free_it)
 
 #
 # Slurm Partition functions

--- a/pyslurm/slurm/extra.pxi
+++ b/pyslurm/slurm/extra.pxi
@@ -273,6 +273,7 @@ cdef extern void slurmdb_job_cond_def_start_end(slurmdb_job_cond_t *job_cond)
 cdef extern uint64_t slurmdb_find_tres_count_in_string(char *tres_str_in, int id)
 cdef extern slurmdb_job_rec_t *slurmdb_create_job_rec()
 cdef extern void slurmdb_init_assoc_rec(slurmdb_assoc_rec_t *assoc, bool free_it)
+cdef extern void slurmdb_init_tres_cond(slurmdb_tres_cond_t *tres, bool free_it)
 
 #
 # Slurm Partition functions

--- a/pyslurm/utils/cstr.pyx
+++ b/pyslurm/utils/cstr.pyx
@@ -186,7 +186,7 @@ def dict_to_str(vals, prepend=None, delim1=",", delim2="="):
         tmp_dict = validate_str_key_value_format(vals, delim1, delim2)
     
     for k, v in tmp_dict.items():
-        if ((delim1 in k or delim2 in k) or
+        if ((delim1 in str(k) or delim2 in str(k)) or
                 delim1 in str(v) or delim2 in str(v)):    
             raise ValueError(
                 f"Key or Value cannot contain either {delim1} or {delim2}. "

--- a/pyslurm/utils/helpers.pyx
+++ b/pyslurm/utils/helpers.pyx
@@ -341,13 +341,13 @@ def instance_to_dict(inst):
     return out
 
 
-def collection_to_dict(collection, by_cluster, is_global_data, identifier):
+def collection_to_dict(collection, is_global_data, identifier, recursive=False):
     cdef dict out = {}
 
     if is_global_data:
         for item in collection:
             _id = identifier.__get__(item)
-            out[_id] = item
+            out[_id] = item if not recursive else item.as_dict()
         return out
 
     for item in collection:
@@ -356,11 +356,7 @@ def collection_to_dict(collection, by_cluster, is_global_data, identifier):
             out[cluster] = {}
 
         _id = identifier.__get__(item)
-        out[cluster][_id] = item
-
-    if not by_cluster:
-        # TODO: Return only local cluster data
-        return out
+        out[cluster][_id] = item if not recursive else item.as_dict()
 
     return out
 

--- a/pyslurm/utils/helpers.pyx
+++ b/pyslurm/utils/helpers.pyx
@@ -406,3 +406,29 @@ def _get_exit_code(exit_code):
                 exit_state -= 128
 
     return exit_state, sig
+
+
+def humanize_step_id(sid):
+    if sid == slurm.SLURM_BATCH_SCRIPT:
+        return "batch"
+    elif sid == slurm.SLURM_EXTERN_CONT:
+        return "extern"
+    elif sid == slurm.SLURM_INTERACTIVE_STEP:
+        return "interactive"
+    elif sid == slurm.SLURM_PENDING_STEP:
+        return "pending"
+    else:
+        return sid
+
+
+def dehumanize_step_id(sid):
+    if sid == "batch":
+        return slurm.SLURM_BATCH_SCRIPT
+    elif sid == "extern":
+        return slurm.SLURM_EXTERN_CONT
+    elif sid == "interactive":
+        return slurm.SLURM_INTERACTIVE_STEP
+    elif sid == "pending":
+        return slurm.SLURM_PENDING_STEP
+    else:
+        return int(sid)

--- a/pyslurm/utils/helpers.pyx
+++ b/pyslurm/utils/helpers.pyx
@@ -341,6 +341,44 @@ def instance_to_dict(inst):
     return out
 
 
+def collection_to_dict(collection, by_cluster, is_global_data, identifier):
+    cdef dict out = {}
+
+    if is_global_data:
+        for item in collection:
+            _id = identifier.__get__(item)
+            out[_id] = item
+        return out
+
+    for item in collection:
+        cluster = item.cluster
+        if cluster not in out:
+            out[cluster] = {}
+
+        _id = identifier.__get__(item)
+        out[cluster][_id] = item
+
+    if not by_cluster:
+        # TODO: Return only local cluster data
+        return out
+
+    return out
+
+
+def group_collection_by_cluster(collection):
+    cdef dict out = {}
+    collection_type = type(collection)
+
+    for item in collection:
+        cluster = item.cluster
+        if cluster not in out:
+            out[cluster] = collection_type()
+
+        out[cluster].append(item)
+    
+    return out
+
+
 def _sum_prop(obj, name, startval=0):
     val = startval
     for n in obj.values():

--- a/pyslurm/utils/helpers.pyx
+++ b/pyslurm/utils/helpers.pyx
@@ -341,14 +341,8 @@ def instance_to_dict(inst):
     return out
 
 
-def collection_to_dict(collection, is_global_data, identifier, recursive=False):
+def collection_to_dict(collection, identifier, recursive=False, group_id=None):
     cdef dict out = {}
-
-    if is_global_data:
-        for item in collection:
-            _id = identifier.__get__(item)
-            out[_id] = item if not recursive else item.as_dict()
-        return out
 
     for item in collection:
         cluster = item.cluster
@@ -356,8 +350,24 @@ def collection_to_dict(collection, is_global_data, identifier, recursive=False):
             out[cluster] = {}
 
         _id = identifier.__get__(item)
-        out[cluster][_id] = item if not recursive else item.as_dict()
+        data = item if not recursive else item.as_dict()
 
+        if group_id:
+            grp_id = group_id.__get__(item)
+            if grp_id not in out[cluster]:
+                out[cluster][grp_id] = {}
+            out[cluster][grp_id].update({_id: data})
+        else:
+            out[cluster][_id] = data
+
+    return out
+
+
+def collection_to_dict_global(collection, identifier, recursive=False):
+    cdef dict out = {}
+    for item in collection:
+        _id = identifier.__get__(item)
+        out[_id] = item if not recursive else item.as_dict()
     return out
 
 

--- a/tests/integration/test_db_job.py
+++ b/tests/integration/test_db_job.py
@@ -59,7 +59,7 @@ def test_modify(submit_job):
     job = submit_job()
     util.wait(5)
 
-    jfilter = pyslurm.db.JobSearchFilter(ids=[job.id])
+    jfilter = pyslurm.db.JobFilter(ids=[job.id])
     changes = pyslurm.db.Job(comment="test comment")
     pyslurm.db.Jobs.modify(jfilter, changes)
 
@@ -72,7 +72,7 @@ def test_modify_with_existing_conn(submit_job):
     util.wait(5)
 
     conn = pyslurm.db.Connection.open()
-    jfilter = pyslurm.db.JobSearchFilter(ids=[job.id])
+    jfilter = pyslurm.db.JobFilter(ids=[job.id])
     changes = pyslurm.db.Job(comment="test comment")
     pyslurm.db.Jobs.modify(jfilter, changes, conn)
 

--- a/tests/integration/test_db_job.py
+++ b/tests/integration/test_db_job.py
@@ -42,7 +42,7 @@ def test_load_single(submit_job):
     assert db_job.id == job.id
 
     with pytest.raises(pyslurm.RPCError):
-        pyslurm.db.Job.load(1000)
+        pyslurm.db.Job.load(0)
 
 
 def test_parse_all(submit_job):

--- a/tests/integration/test_db_qos.py
+++ b/tests/integration/test_db_qos.py
@@ -50,6 +50,6 @@ def test_load_all():
 
 
 def test_load_with_filter_name():
-    qfilter = pyslurm.db.QualityOfServiceSearchFilter(names=["non_existent"])
+    qfilter = pyslurm.db.QualityOfServiceFilter(names=["non_existent"])
     qos = pyslurm.db.QualitiesOfService.load(qfilter)
     assert not qos

--- a/tests/integration/test_job.py
+++ b/tests/integration/test_job.py
@@ -150,7 +150,7 @@ def test_get_job_queue(submit_job):
     # Submit 10 jobs, gather the job_ids in a list
     job_list = [submit_job() for i in range(10)]
 
-    jobs = Jobs.load()
+    jobs = Jobs.load().as_dict()
     for job in job_list:
         # Check to see if all the Jobs we submitted exist
         assert job.id in jobs

--- a/tests/integration/test_job_steps.py
+++ b/tests/integration/test_job_steps.py
@@ -102,7 +102,7 @@ def test_collection(submit_job):
     job = submit_job(script=create_job_script_multi_step())
 
     time.sleep(util.WAIT_SECS_SLURMCTLD)
-    steps = JobSteps.load(job)
+    steps = JobSteps.load(job).as_dict()
 
     assert steps != {}
     # We have 3 Steps: batch, 0 and 1
@@ -116,7 +116,7 @@ def test_cancel(submit_job):
     job = submit_job(script=create_job_script_multi_step())
 
     time.sleep(util.WAIT_SECS_SLURMCTLD)
-    steps = JobSteps.load(job)
+    steps = JobSteps.load(job).as_dict()
     assert len(steps) == 3
     assert ("batch" in steps and
             0 in steps and
@@ -125,7 +125,7 @@ def test_cancel(submit_job):
     steps[0].cancel()
     
     time.sleep(util.WAIT_SECS_SLURMCTLD)
-    steps = JobSteps.load(job)
+    steps = JobSteps.load(job).as_dict()
     assert len(steps) == 2
     assert ("batch" in steps and
             1 in steps)

--- a/tests/integration/test_job_steps.py
+++ b/tests/integration/test_job_steps.py
@@ -104,7 +104,7 @@ def test_collection(submit_job):
     time.sleep(util.WAIT_SECS_SLURMCTLD)
     steps = JobSteps.load(job).as_dict()
 
-    assert steps != {}
+    assert steps
     # We have 3 Steps: batch, 0 and 1
     assert len(steps) == 3
     assert ("batch" in steps and

--- a/tests/integration/test_node.py
+++ b/tests/integration/test_node.py
@@ -29,7 +29,7 @@ from pyslurm import Node, Nodes, RPCError
 
 
 def test_load():
-    name = Nodes.load().as_list()[0].name
+    name = Nodes.load()[0].name
 
     # Now load the node info
     node = Node.load(name)
@@ -56,7 +56,7 @@ def test_create():
 
 
 def test_modify():
-    node = Node(Nodes.load().as_list()[0].name)
+    node = Node(Nodes.load()[0].name)
 
     node.modify(Node(weight=10000))
     assert Node.load(node.name).weight == 10000
@@ -69,4 +69,4 @@ def test_modify():
 
 
 def test_parse_all():
-    Node.load(Nodes.load().as_list()[0].name).as_dict()
+    Node.load(Nodes.load()[0].name).as_dict()

--- a/tests/integration/test_partition.py
+++ b/tests/integration/test_partition.py
@@ -28,7 +28,7 @@ from pyslurm import Partition, Partitions, RPCError
 
 
 def test_load():
-    part = Partitions.load().as_list()[0]
+    part = Partitions.load()[0]
 
     assert part.name
     assert part.state
@@ -49,7 +49,7 @@ def test_create_delete():
 
 
 def test_modify():
-    part = Partitions.load().as_list()[0]
+    part = Partitions.load()[0]
 
     part.modify(Partition(default_time=120))
     assert Partition.load(part.name).default_time == 120
@@ -68,22 +68,23 @@ def test_modify():
 
 
 def test_parse_all():
-    Partitions.load().as_list()[0].as_dict()
+    Partitions.load()[0].as_dict()
 
 
 def test_reload():
     _partnames = [util.randstr() for i in range(3)]
     _tmp_parts = Partitions(_partnames)
-    for part in _tmp_parts.values():
+    for part in _tmp_parts:
         part.create()
 
     all_parts = Partitions.load()
     assert len(all_parts) >= 3
 
     my_parts = Partitions(_partnames[1:]).reload()
+    print(my_parts)
     assert len(my_parts) == 2
-    for part in my_parts.as_list():
+    for part in my_parts:
         assert part.state != "UNKNOWN"
     
-    for part in _tmp_parts.values():
+    for part in _tmp_parts:
         part.delete()

--- a/tests/unit/test_db_job.py
+++ b/tests/unit/test_db_job.py
@@ -25,7 +25,7 @@ import pyslurm
 
 
 def test_filter():
-    job_filter = pyslurm.db.JobSearchFilter()
+    job_filter = pyslurm.db.JobFilter()
 
     job_filter.clusters = ["test1"]
     job_filter.partitions = ["partition1", "partition2"]

--- a/tests/unit/test_db_job.py
+++ b/tests/unit/test_db_job.py
@@ -45,6 +45,7 @@ def test_filter():
 def test_create_collection():
     jobs = pyslurm.db.Jobs("101,102")
     assert len(jobs) == 2
+    jobs = jobs.as_dict()
     assert 101 in jobs
     assert 102 in jobs
     assert jobs[101].id == 101
@@ -52,6 +53,7 @@ def test_create_collection():
 
     jobs = pyslurm.db.Jobs([101, 102])
     assert len(jobs) == 2
+    jobs = jobs.as_dict()
     assert 101 in jobs
     assert 102 in jobs
     assert jobs[101].id == 101
@@ -64,6 +66,7 @@ def test_create_collection():
         }
     )
     assert len(jobs) == 2
+    jobs = jobs.as_dict()
     assert 101 in jobs
     assert 102 in jobs
     assert jobs[101].id == 101

--- a/tests/unit/test_db_qos.py
+++ b/tests/unit/test_db_qos.py
@@ -25,7 +25,7 @@ import pyslurm
 
 
 def test_search_filter():
-    qos_filter = pyslurm.db.QualityOfServiceSearchFilter()
+    qos_filter = pyslurm.db.QualityOfServiceFilter()
     qos_filter._create()
 
     qos_filter.ids = [1, 2]

--- a/tests/unit/test_job_steps.py
+++ b/tests/unit/test_job_steps.py
@@ -22,7 +22,7 @@
 
 import pytest
 from pyslurm import JobStep, Job
-from pyslurm.core.job.step import (
+from pyslurm.utils.helpers import (
     humanize_step_id,
     dehumanize_step_id,
 )

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -36,14 +36,14 @@ def test_parse_all():
 
 
 def test_create_nodes_collection():
-    nodes = Nodes("node1,node2")
+    nodes = Nodes("node1,node2").as_dict()
     assert len(nodes) == 2
     assert "node1" in nodes
     assert "node2" in nodes
     assert nodes["node1"].name == "node1"
     assert nodes["node2"].name == "node2"
 
-    nodes = Nodes(["node1", "node2"])
+    nodes = Nodes(["node1", "node2"]).as_dict()
     assert len(nodes) == 2
     assert "node1" in nodes
     assert "node2" in nodes
@@ -55,7 +55,7 @@ def test_create_nodes_collection():
             "node1": Node("node1"),
             "node2": Node("node2"),
         }
-    )
+    ).as_dict()
     assert len(nodes) == 2
     assert "node1" in nodes
     assert "node2" in nodes

--- a/tests/unit/test_partition.py
+++ b/tests/unit/test_partition.py
@@ -32,14 +32,14 @@ def test_create_instance():
 
 
 def test_create_collection():
-    parts = Partitions("part1,part2")
+    parts = Partitions("part1,part2").as_dict()
     assert len(parts) == 2
     assert "part1" in parts
     assert "part2" in parts
     assert parts["part1"].name == "part1"
     assert parts["part2"].name == "part2"
 
-    parts = Partitions(["part1", "part2"])
+    parts = Partitions(["part1", "part2"]).as_dict()
     assert len(parts) == 2
     assert "part1" in parts
     assert "part2" in parts
@@ -51,7 +51,7 @@ def test_create_collection():
             "part1": Partition("part1"),
             "part2": Partition("part2"),
         }
-    )
+    ).as_dict()
     assert len(parts) == 2
     assert "part1" in parts
     assert "part2" in parts


### PR DESCRIPTION
- All collections inherit from `list` instead of `dict` now (this change is mostly motivated by multi-cluster support that will probably be added in the future)
- Added work-in-progress API for database `Associations`
- renamed `JobSearchFilter` to `JobFilter`