### PR TITLE
Correctly calculate memory of the job

### DIFF
--- a/pyslurm/core/job/job.pyx
+++ b/pyslurm/core/job/job.pyx
@@ -1093,10 +1093,11 @@ cdef class Job:
 
         mem_node = self.memory_per_node
         if mem_node is not None:
-            num_nodes = self.min_nodes
+            num_nodes = self.num_nodes
             if num_nodes is not None:
                 mem_node *= num_nodes
-            return mem_cpu
+            return mem_node
+
 
         # TODO
         #   mem_gpu = self.memory_per_gpu


### PR DESCRIPTION
- Replace min_nodes (which doesn't exist) with num_nodes
- Return mem_node instead of mem_cpu.

Based on the commented out code beneath it, this looks like a copy/paste error.  It would go unnoticed so long as mem_cpu was a non-None value.