### PR TITLE
Add codespell (workflow and config) to catch typos, fix some caught now

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -44,7 +44,7 @@ confidence=
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes

--- a/UPGRADE_C_API.rst
+++ b/UPGRADE_C_API.rst
@@ -48,7 +48,7 @@ Then, simply generate the header definitions like in this example:
 
 .. code-block:: bash
 
-    scripts/pyslurm_bindgen.py -D /directoy/with/slurm/headers > pyslurm/slurm/header.pxi
+    scripts/pyslurm_bindgen.py -D /directory/with/slurm/headers > pyslurm/slurm/header.pxi
 
 The script outputs everything to `stdout`. Simply redirect the output to the file: :code:`pyslurm/slurm/header.pxi`.
 The headers should now be fully translated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ requires = [
 skip = '.git,*.pdf,*.svg,*.lock,*.css'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+# ignore some variables etc
+ignore-words-list = 'mmaped,splitted'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,9 @@ requires = [
     "Cython>=0.29.30,<3.0",
 ]
 
+
+[tool.codespell]
+skip = '.git,*.pdf,*.svg,*.lock,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyslurm/core/error.pyx
+++ b/pyslurm/core/error.pyx
@@ -51,7 +51,7 @@ def slurm_errno():
 
 
 def get_last_slurm_error():
-    """Get the last slurm error that occured as a tuple of errno and string.
+    """Get the last slurm error that occurred as a tuple of errno and string.
 
     Returns:
         errno (int): The error number

--- a/pyslurm/core/job/job.pxd
+++ b/pyslurm/core/job/job.pxd
@@ -1,5 +1,5 @@
 #########################################################################
-# job.pyx - interface to retrieve slurm job informations
+# job.pyx - interface to retrieve slurm job information
 #########################################################################
 # Copyright (C) 2023 Toni Harzendorf <toni.harzendorf@gmail.com>
 #
@@ -353,7 +353,7 @@ cdef class Job:
         kill_on_invalid_dependency (bool):
             Whether the Job should be killed on an invalid dependency.
         spreads_over_nodes (bool):
-            Whether the Job should be spreaded over as many nodes as possible.
+            Whether the Job should be spread over as many nodes as possible.
         power_options (list):
             Options set for Power Management.
         is_cronjob (bool):

--- a/pyslurm/core/job/job.pyx
+++ b/pyslurm/core/job/job.pyx
@@ -1,5 +1,5 @@
 #########################################################################
-# job.pyx - interface to retrieve slurm job informations
+# job.pyx - interface to retrieve slurm job information
 #########################################################################
 # Copyright (C) 2023 Toni Harzendorf <toni.harzendorf@gmail.com>
 #

--- a/pyslurm/core/job/sbatch_opts.pyx
+++ b/pyslurm/core/job/sbatch_opts.pyx
@@ -40,7 +40,7 @@ class _SbatchOpt():
         self.has_optional_args = has_optional_args
 
 
-# Sorted by occurence in the sbatch manpage - keep in order.
+# Sorted by occurrence in the sbatch manpage - keep in order.
 SBATCH_OPTIONS = [
     _SbatchOpt("A", "account", "account"),
     _SbatchOpt(None, "acctg-freq", "accounting_gather_frequency"),

--- a/pyslurm/core/job/step.pxd
+++ b/pyslurm/core/job/step.pxd
@@ -1,5 +1,5 @@
 #########################################################################
-# job/step.pxd - interface to retrieve slurm job step informations
+# job/step.pxd - interface to retrieve slurm job step information
 #########################################################################
 # Copyright (C) 2023 Toni Harzendorf <toni.harzendorf@gmail.com>
 #

--- a/pyslurm/core/job/step.pyx
+++ b/pyslurm/core/job/step.pyx
@@ -1,5 +1,5 @@
 #########################################################################
-# job/step.pyx - interface to retrieve slurm job step informations
+# job/step.pyx - interface to retrieve slurm job step information
 #########################################################################
 # Copyright (C) 2023 Toni Harzendorf <toni.harzendorf@gmail.com>
 #

--- a/pyslurm/core/job/submission.pxd
+++ b/pyslurm/core/job/submission.pxd
@@ -342,13 +342,13 @@ cdef class JobSubmitDescription:
             This is the same as --cpus-per-gpu from sbatch.
             This is mutually exclusive with `cpus_per_task`.
         sockets_per_node (int):
-            Restrict Job to nodes with atleast this many sockets.
+            Restrict Job to nodes with at least this many sockets.
             This is the same as --sockets-per-node from sbatch.
         cores_per_socket (int):
-            Restrict Job to nodes with atleast this many cores per socket
+            Restrict Job to nodes with at least this many cores per socket
             This is the same as --cores-per-socket from sbatch.
         threads_per_core (int):
-            Restrict Job to nodes with atleast this many threads per socket
+            Restrict Job to nodes with at least this many threads per socket
             This is the same as --threads-per-core from sbatch.
         gpus (Union[dict, str, int]):
             GPUs for the Job to be allocated in total.
@@ -421,7 +421,7 @@ cdef class JobSubmitDescription:
 
             This is the same as --gres from sbatch. You should also use this
             option if you want to specify GPUs per node (--gpus-per-node).
-            Specifying the type (by seperating GRES name and type with a
+            Specifying the type (by separating GRES name and type with a
             semicolon) is optional. 
 
             For example, specifying it as a dict:

--- a/pyslurm/db/job.pyx
+++ b/pyslurm/db/job.pyx
@@ -224,7 +224,7 @@ cdef class Jobs(MultiClusterMap):
 
         Raises:
             RPCError: When getting the Jobs from the Database was not
-                sucessful
+                successful
 
         Examples:
             Without a Filter the default behaviour applies, which is
@@ -278,7 +278,7 @@ cdef class Jobs(MultiClusterMap):
         # convert them to its type name for the user in advance.
 
         # TODO: How to handle the possibility of duplicate job ids that could
-        # appear if IDs on a cluster are resetted?
+        # appear if IDs on a cluster are reset?
         for job_ptr in SlurmList.iter_and_pop(job_data):
             job = Job.from_ptr(<slurmdb_job_rec_t*>job_ptr.data)
             job.qos_data = qos_data
@@ -497,7 +497,7 @@ cdef class Job:
 
         Raises:
             RPCError: If requesting the information for the database Job was
-                not sucessful.
+                not successful.
 
         Examples:
             >>> import pyslurm
@@ -838,7 +838,7 @@ cdef class Job:
 
     @property
     def user_name(self):
-        # Theres also a ptr->user
+        # There's also a ptr->user
         # https://github.com/SchedMD/slurm/blob/6365a8b7c9480c48678eeedef99864d8d3b6a6b5/src/sacct/print.c#L1946
         return uid_to_name(self.ptr.uid)
 

--- a/pyslurm/db/qos.pyx
+++ b/pyslurm/db/qos.pyx
@@ -181,7 +181,7 @@ cdef class QualityOfService:
 
         Raises:
             RPCError: If requesting the information from the database was not
-                sucessful.
+                successful.
         """
         qfilter = QualityOfServiceFilter(names=[name])
         qos = QualitiesOfService.load(qfilter).get(name)

--- a/pyslurm/db/stats.pxd
+++ b/pyslurm/db/stats.pxd
@@ -65,39 +65,39 @@ cdef class JobStatistics:
         max_disk_read (int):
             Highest peak number of bytes read by all tasks
         max_disk_read_node (int):
-            Name of the Node where max_disk_read occured
+            Name of the Node where max_disk_read occurred
         max_disk_read_task (int):
-            ID of the Task where max_disk_read occured
+            ID of the Task where max_disk_read occurred
         max_disk_write (int):
             Lowest peak number of bytes written by all tasks
         max_disk_write_node (int):
-            Name of the Node where max_disk_write occured
+            Name of the Node where max_disk_write occurred
         max_disk_write_task (int):
-            ID of the Task where max_disk_write occured
+            ID of the Task where max_disk_write occurred
         max_page_faults (int):
             Highest peak number of page faults by all tasks
         max_page_faults_node (int):
-            Name of the Node where max_page_faults occured
+            Name of the Node where max_page_faults occurred
         max_page_faults_task (int):
-            ID of the Task where max_page_faults occured
+            ID of the Task where max_page_faults occurred
         max_resident_memory (int):
             Highest peak Resident Set Size (RSS) in bytes by all tasks
         max_resident_memory_node (int):
-            Name of the Node where max_resident_memory occured
+            Name of the Node where max_resident_memory occurred
         max_resident_memory_task (int):
-            ID of the Task where max_resident_memory occured
+            ID of the Task where max_resident_memory occurred
         max_virtual_memory (int):
             Highest peak Virtual Memory Size (VSZ) in bytes by all tasks
         max_virtual_memory_node (int):
-            Name of the Node where max_virtual_memory occured
+            Name of the Node where max_virtual_memory occurred
         max_virtual_memory_task (int):
-            ID of the Task where max_virtual_memory occured
+            ID of the Task where max_virtual_memory occurred
         min_cpu_time (int):
             Lowest peak CPU-Time (System + User) in seconds of all tasks
         min_cpu_time_node (int):
-            Name of the Node where min_cpu_time occured
+            Name of the Node where min_cpu_time occurred
         min_cpu_time_task (int):
-            ID of the Task where min_cpu_time occured
+            ID of the Task where min_cpu_time occurred
         total_cpu_time (int):
             Sum of user_cpu_time and system_cpu_time, in seconds
         user_cpu_time (int):

--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -2985,7 +2985,7 @@ cdef class job:
                     # set exit code to the highest of all jobs in job array
                     exit_status = max([exit_status, exit_status_arrayjob])
                 else:
-                    # go on with the next interation, unil all jobs in array are completed
+                    # go on with the next iteration, unil all jobs in array are completed
                     complete = False
             slurm.slurm_free_job_info_msg(self._job_ptr)
         return exit_status

--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -45,7 +45,7 @@ cdef extern from "<sys/resource.h>" nogil:
     int getpriority(int, id_t)
 
 #cdef extern from *:
-#    # deprecated backwards compatiblity declaration
+#    # deprecated backwards compatibility declaration
 #    ctypedef char*  const_char_ptr  "const char*"
 #    ctypedef char** const_char_pptr "const char**"
 
@@ -1807,9 +1807,9 @@ cdef class job:
     cdef _load_single_job(self, jobid):
         """Uses slurm_load_job to setup the self._job_ptr for a single job given by the jobid.
         After calling this, the job pointer can be used in other methods
-        to operate on the informations of the job.
+        to operate on the information of the job.
 
-        This method accepts both string and integer formate of the jobid. It
+        This method accepts both string and integer format of the jobid. It
         calls slurm_xlate_job_id to convert the jobid appropriately.
 
         Raises an value error if the jobid does not correspond to a existing job.
@@ -2307,7 +2307,7 @@ cdef class job:
             bit_str (str): string describing a bitmap (e.g. "0-30,45,50-60")
 
         Returns:
-            (list): List referring to bitmap (empty if not succesful)
+            (list): List referring to bitmap (empty if not successful)
         """
         r_list = []
 

--- a/pyslurm/utils/cstr.pyx
+++ b/pyslurm/utils/cstr.pyx
@@ -72,7 +72,7 @@ cdef fmalloc(char **old, val):
         const char *tmp = NULL
         size_t size
 
-    # Free the previous allocation (if neccessary)
+    # Free the previous allocation (if necessary)
     xfree(old[0])
 
     # Consider: Maybe every string containing a \0 should just
@@ -158,7 +158,7 @@ def validate_str_key_value_format(val, delim1=",", delim2="="):
         else:
             raise ValueError(
                 f"Invalid format for key-value pair {kv}. "
-                f"Expected {delim2} as seperator."
+                f"Expected {delim2} as separator."
             )
 
     return out

--- a/pyslurm/utils/cstr.pyx
+++ b/pyslurm/utils/cstr.pyx
@@ -70,7 +70,7 @@ cdef fmalloc(char **old, val):
     # allow for a denial of service attack on services that use pyslurm.
     cdef:
         const char *tmp = NULL
-        size_t siz
+        size_t size
 
     # Free the previous allocation (if neccessary)
     xfree(old[0])
@@ -85,13 +85,13 @@ cdef fmalloc(char **old, val):
         tmp = val
 
         # Get the length of the char*, include space for NUL character
-        siz = <size_t>strlen(tmp) + 1
+        size = <size_t>strlen(tmp) + 1
 
-        old[0] = <char *>slurm.try_xmalloc(siz)
+        old[0] = <char *>slurm.try_xmalloc(size)
         if not old[0]:
             raise MemoryError("xmalloc failed for char*")
 
-        memcpy(old[0], tmp, siz)
+        memcpy(old[0], tmp, size)
     else:
         old[0] = NULL
 

--- a/tests/integration/test_db_connection.py
+++ b/tests/integration/test_db_connection.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License along
 # with PySlurm; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-"""test_db_connection.py - Test database connectin api functionalities."""
+"""test_db_connection.py - Test database connecting api functionalities."""
 
 import pytest
 import pyslurm


### PR DESCRIPTION
there is one change to the code (`siz` -> `size`) -- I hope there is tests, but I do not expect sideeffect there