### PR TITLE
Fix a crash in cstr.to_gres_dict when the input is just "gres:gpu"

### DIFF
--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -152,12 +152,32 @@ class TestStrings:
         assert cstr.from_gres_dict("tesla:3,a100:5", "gpu") == expected_str
 
     def test_str_to_gres_dict(self):
-        input_str = "gpu:nvidia-a100:1(IDX:0,1)"
-        expected = {"gpu:nvidia-a100":{"count": 1, "indexes": "0,1"}}
+        input_str = "gpu:nvidia-a100:1(IDX:0)"
+        expected = {"gpu:nvidia-a100": {"count": 1, "indexes": "0"}}
         assert cstr.to_gres_dict(input_str) == expected
 
-        input_str = "gpu:nvidia-a100:1"
-        expected = {"gpu:nvidia-a100": 1}
+        input_str = "gpu:nvidia-a100:2(IDX:0,1)"
+        expected = {"gpu:nvidia-a100": {"count": 2, "indexes": "0,1"}}
+        assert cstr.to_gres_dict(input_str) == expected
+
+        input_str = "gpu:nvidia-a100:5"
+        expected = {"gpu:nvidia-a100": 5}
+        assert cstr.to_gres_dict(input_str) == expected
+
+        input_str = "gpu:nvidia-a100:5,gres:gpu:nvidia-v100:10"
+        expected = {"gpu:nvidia-a100": 5, "gpu:nvidia-v100": 10}
+        assert cstr.to_gres_dict(input_str) == expected
+
+        input_str = "gres:gpu:2"
+        expected = {"gpu": 2}
+        assert cstr.to_gres_dict(input_str) == expected
+
+        input_str = "gres:gpu"
+        expected = {"gpu": 1}
+        assert cstr.to_gres_dict(input_str) == expected
+
+        input_str = "gres:gpu:INVALID_COUNT"
+        expected = {}
         assert cstr.to_gres_dict(input_str) == expected
 
     def test_gres_from_tres_dict(self):


### PR DESCRIPTION
Slurm allows to pass things like --gres=gpu, which in this case the default value will be just one. However, the char *gres value also really just contains "gres:gpu" when displayed via scontrol, with no indication of the count. The code previously assumed that Slurm internally modifies the char* explicitly to reflect the default count of 1.

Fixes #333 