### PR TITLE
add missing member in job_resources struct definition

### DIFF
--- a/pyslurm/slurm/extra.pxi
+++ b/pyslurm/slurm/extra.pxi
@@ -153,6 +153,7 @@ ctypedef struct job_resources:
     uint16_t  cr_type
     uint64_t *memory_allocated
     uint64_t *memory_used
+    uint32_t  next_step_node_inx
     uint32_t  nhosts
     bitstr_t *node_bitmap
     uint32_t  node_req


### PR DESCRIPTION
Closes #380 