### PR TITLE
fix the nice priority value

### DIFF
--- a/pyslurm/core/job/job.pyx
+++ b/pyslurm/core/job/job.pyx
@@ -714,7 +714,7 @@ cdef class Job:
         if self.ptr.nice == slurm.NO_VAL:
             return None
 
-        return self.ptr.nice - slurm.NICE_OFFSET
+        return int(self.ptr.nice) - slurm.NICE_OFFSET
 
     @property
     def qos(self):


### PR DESCRIPTION
I've been porting some of our codes from job() to Job() and noticed that 'nice' is incorrect in the new API.
nice was always ballpark 4294097297

this change fixed it for me.