### PR TITLE
return tres_per_task as a dict

### DIFF
--- a/pyslurm/core/job/job.pyx
+++ b/pyslurm/core/job/job.pyx
@@ -1238,6 +1238,10 @@ cdef class Job:
         return cstr.to_gres_dict(self.ptr.tres_per_node)
 
     @property
+    def tres_per_task(self):
+        return cstr.to_dict(self.ptr.tres_per_task)
+
+    @property
     def profile_types(self):
         return acctg_profile_int_to_list(self.ptr.profile)
 


### PR DESCRIPTION
the old job API had tres_req_str which we were using when folks request gpus-per-task. eg. requests like this

#SBATCH  --nodes=6-24 --ntasks=24 --cpus-per-task=1  --gpus-per-task=1 --mem-per-cpu=8g

I couldn't find anything equivalent to tres_req_str in the new Job API, so I added this code that parses tres_per_task into a dict in a vaguely similar way to how you do gres_per_task. ie.

cpu=1,gres/gpu=1  -->  {'cpu': 1, 'gres/gpu': 1}

full disclosure - this is my first attempt at cython code, so is probably sketchy :)

sadly(?) there are a bunch of other tres_per_{job,node,task,socket} things in slurm now, not just this one.
however this patch solves our problem for the moment.

anyway, I thought I'd contrib this back and maybe it'd kickstart a discussion on how/if you want to support these kind of tres_per_* things, and if you just want to pass back a _str, or if a dict is nicer, or ... ?