### PR TITLE
Fix syntax error in f-string in submission.pyx

### DIFF
--- a/pyslurm/core/job/submission.pyx
+++ b/pyslurm/core/job/submission.pyx
@@ -168,7 +168,7 @@ cdef class JobSubmitDescription:
                 continue
 
             spec = attr.upper()
-            val = pyenviron.get(f"PYSLURM_JOBDESC_{spec)}")
+            val = pyenviron.get(f"PYSLURM_JOBDESC_{spec}")
             if (val is not None
                     and (getattr(self, attr) is None or overwrite)):
 


### PR DESCRIPTION
This has been in here for years (since 2023) and causes parsing errors in Cython.