### PR TITLE
Fix syntax error in submission.pyx

### DIFF
--- a/pyslurm/core/job/submission.pyx
+++ b/pyslurm/core/job/submission.pyx
@@ -168,7 +168,7 @@ cdef class JobSubmitDescription:
                 continue
 
             spec = attr.upper()
-            val = pyenviron.get(f"PYSLURM_JOBDESC_{spec)}")
+            val = pyenviron.get(f"PYSLURM_JOBDESC_{spec}")
             if (val is not None
                     and (getattr(self, attr) is None or overwrite)):
 


### PR DESCRIPTION
Branch encountered a build error due to a typo/syntax error in `pyslurm/core/job/submission.pyx`. Fixed this. Tested with slurm 23.11.4.